### PR TITLE
팔로워 페이지 UI 구현

### DIFF
--- a/src/components/common/BaseHeader/index.jsx
+++ b/src/components/common/BaseHeader/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 const SContainer = styled.header`
+  position: sticky;
+  top: 0;
   width: 100%;
   display: flex;
   justify-content: space-between;

--- a/src/components/common/Button/index.jsx
+++ b/src/components/common/Button/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const SButton = styled.button`
   width: ${({ buttonStyle }) =>
@@ -19,11 +19,30 @@ const SButton = styled.button`
     cursor: default;
     background-color: ${({ theme }) => theme.color.DISABLED_BLUE};
   }
+
+  ${(type) =>
+    type.cancel &&
+    css`
+      color: ${({ theme }) => theme.color.GRAY};
+      background-color: ${({ theme }) => theme.color.WHITE};
+      border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+
+      &:active,
+      &:hover {
+        background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
+        color: ${({ theme }) => theme.color.WHITE};
+      }
+    `}
 `;
 
-function Button({ text, buttonStyle, onClick, disabled }) {
+function Button({ text, buttonStyle, onClick, disabled, ...type }) {
   return (
-    <SButton buttonStyle={buttonStyle} disabled={disabled} onClick={onClick}>
+    <SButton
+      {...type}
+      buttonStyle={buttonStyle}
+      disabled={disabled}
+      onClick={onClick}
+    >
       {text}
     </SButton>
   );

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -79,6 +79,34 @@ function Follower() {
             background="pink"
           />
         </SContent>
+
+        <SContent>
+          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
+          <STextItem>
+            <STextUserId>
+              안녕하세요, 사용자 이름입니다. 이러쿵 저러쿵 어쩌고 저쩌고
+            </STextUserId>
+            <STextIntroduction>
+              안녕하세요, 제 소개를 하자면요. 이러쿵 저러쿵 어쩌고 저쩌고
+            </STextIntroduction>
+          </STextItem>
+          <Button cancel text="취소" buttonStyle={FOLLOW_BUTTON} />
+        </SContent>
+
+        <SContent>
+          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
+          <STextItem>
+            <STextUserId>userId</STextUserId>
+            <STextIntroduction>Hello, world!</STextIntroduction>
+          </STextItem>
+          <Button
+            cancel
+            text="취소"
+            buttonStyle={FOLLOW_BUTTON}
+            color="green"
+            background="pink"
+          />
+        </SContent>
       </SContainer>
     </div>
   );

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -16,12 +16,69 @@ const STitle = styled.h2`
   ${IR}
 `;
 
+const SContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.6rem;
+  align-items: center;
+`;
+
+const STextItem = styled.div`
+  margin: 0 1.2rem;
+`;
+
+const SImg = styled.img`
+  width: 5rem;
+`;
+
+const STextUserId = styled.p`
+  width: 22.8rem;
+  margin-bottom: 0.6rem;
+  font-size: 1.4rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const STextIntroduction = styled.p`
+  width: 22.8rem;
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.color.GRAY};
+  ${slEllipsis}
+`;
+
 function Follower() {
   return (
     <div>
       <BaseHeader leftIcon={arrowIcon} title="Follower" />
       <SContainer>
         <STitle>팔로워 페이지</STitle>
+        <SContent>
+          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
+          <STextItem>
+            <STextUserId>
+              안녕하세요, 사용자 이름입니다. 이러쿵 저러쿵 어쩌고 저쩌고
+            </STextUserId>
+            <STextIntroduction>
+              안녕하세요, 제 소개를 하자면요. 이러쿵 저러쿵 어쩌고 저쩌고
+            </STextIntroduction>
+          </STextItem>
+          <Button text="팔로우" buttonStyle={FOLLOW_BUTTON} />
+        </SContent>
+
+        <SContent>
+          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
+          <STextItem>
+            <STextUserId>userId</STextUserId>
+            <STextIntroduction>Hello, world!</STextIntroduction>
+          </STextItem>
+          <Button
+            text="팔로우"
+            buttonStyle={FOLLOW_BUTTON}
+            color="green"
+            background="pink"
+          />
+        </SContent>
       </SContainer>
     </div>
   );

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -1,7 +1,30 @@
 import React from 'react';
+import styled from 'styled-components';
+import BaseHeader from '../../../components/common/BaseHeader';
+import Button from '../../../components/common/Button';
+import { FOLLOW_BUTTON } from '../../../constants/buttonStyle';
+
+import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
+import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
+import { IR, slEllipsis } from '../../../styles/Util';
+
+const SContainer = styled.section`
+  padding: 24px 16px 0;
+`;
+
+const STitle = styled.h2`
+  ${IR}
+`;
 
 function Follower() {
-  return <div>Follower</div>;
+  return (
+    <div>
+      <BaseHeader leftIcon={arrowIcon} title="Follower" />
+      <SContainer>
+        <STitle>팔로워 페이지</STitle>
+      </SContainer>
+    </div>
+  );
 }
 
 export default Follower;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일 : 
  - 팔로우 페이지 모바일 버전 UI 구현
  - 사용자 Id와 소개 글이 길어졌을 경우를 대비하여 마크업
  - 취소 버튼의 경우 active와 hover 할 때의 색상 추가 

## 💬 전달사항
- 취소 버튼 UI를 위해 components/common/Button/index.jsx 코드가 변경되었으니 확인 부탁드려요.

## 💬 스크린샷
![스크린샷 2022-12-13 14 39 22](https://user-images.githubusercontent.com/74060716/207235682-f3efdcba-c890-420b-829e-7bb1381bd917.png)

## 💬 Issue Number
close : #17 
