### PR TITLE
Header, Navigation 부족한 속성 추가

### DIFF
--- a/src/components/Post/PostItem/index.jsx
+++ b/src/components/Post/PostItem/index.jsx
@@ -11,7 +11,7 @@ const SPostItem = styled.li`
   position: relative;
   width: 100%;
   padding: 1.4rem;
-  border: 1px solid gray;
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   border-radius: 1rem;
 `;
 

--- a/src/components/common/BaseHeader/index.jsx
+++ b/src/components/common/BaseHeader/index.jsx
@@ -2,15 +2,19 @@ import React from 'react';
 import styled from 'styled-components';
 
 const SContainer = styled.header`
-  position: sticky;
-  top: 0;
-  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: sticky;
+  top: 0;
+
+  width: 100%;
   padding: 0.75rem 1.6rem;
+
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   background-color: ${({ theme }) => theme.color.WHITE};
+
+  z-index: 100;
 `;
 
 const SButton = styled.button`

--- a/src/components/common/ConfirmHeader/index.jsx
+++ b/src/components/common/ConfirmHeader/index.jsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
-import Button from '../../Button';
+import Button from '../Button';
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 import { SMALL_BUTTON } from '../../../constants/buttonStyle';
 
 const SContainer = styled.header`
-  width: 100%;
   display: flex;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+
+  width: 100%;
   padding: 0.825rem 1.6rem;
+
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   background-color: ${({ theme }) => theme.color.WHITE};
+
+  z-index: 100;
 `;
 
 const SButton = styled.button`

--- a/src/components/common/Navigation/index.jsx
+++ b/src/components/common/Navigation/index.jsx
@@ -23,6 +23,7 @@ const SContainer = styled.div`
   width: 100%;
   padding: 0rem 2rem;
 
+  background-color: ${({ theme }) => theme.color.WHITE};
   border-top: 1px solid #dddddd;
 `;
 

--- a/src/components/common/SearchHeader/index.jsx
+++ b/src/components/common/SearchHeader/index.jsx
@@ -3,12 +3,18 @@ import styled from 'styled-components';
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 
 const SContainer = styled.header`
-  width: 100%;
   display: flex;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+
+  width: 100%;
   padding: 0.8rem 1.6rem;
+
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   background-color: ${({ theme }) => theme.color.WHITE};
+
+  z-index: 100;
 `;
 
 const SButton = styled.button`

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -14,9 +14,10 @@ const SContainer = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100vh;
+  height: calc(100 + 4.4) vh;
 
   padding: 0.9rem;
+  margin-bottom: 6rem;
 `;
 
 const SEmptyContainer = styled.section`


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일 : Header, Navigation 스타일 수정

## 💬 전달사항
- Header가 존재하는 페이지에서 height가 100vh속성을 주는 경우
  - height의 높이를 100+4.4(헤더 높이)로 설정해야함
- page에 Navigation이 있다면 margin-bottom 6rem(Nav 높이)만큼 추가해야함


## 💬 Issue Number
close : #24 
