### PR TITLE
게시글 상세 페이지 UI 마크업 초안 구현

### DIFF
--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
+import { IR } from '../../../styles/Util';
+
+const SContents = styled.section`
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+
+  padding: 1.25rem 1.6rem;
+
+  background-color: ${({ theme }) => theme.color.WHITE};
+  border-top: 0.05rem solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+const STitle = styled.h2`
+  ${IR}
+`;
+
+const SProfileImg = styled.img`
+  width: 3.6rem;
+`;
+
+const SLabel = styled.label`
+  ${IR}
+`;
+
+const SInputForm = styled.input`
+  width: 100%;
+  margin: 0 1.8rem;
+  border-style: none;
+`;
+
+const SButton = styled.button`
+  width: 2.5rem;
+  font-size: 1.4rem;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+function CommentInput({ id }) {
+  return (
+    <SContents>
+      <STitle>댓글 입력</STitle>
+      <SProfileImg src={basicProfilSmallImg} alt="프로필 이미지" />
+      <SLabel htmlFor={id} />
+      <SInputForm id={id} placeholder="댓글 입력하기..." />
+      <SButton type="button">게시</SButton>
+    </SContents>
+  );
+}
+
+export default CommentInput;

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
+import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
+
+const SContents = styled.div`
+  height: 5.8rem;
+  margin: 0 1.6rem 1.6rem;
+`;
+
+const SCommentsInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SUserInfo = styled.div`
+  width: 100%;
+  margin: 0 1.2rem;
+  font-size: 1.4rem;
+`;
+
+const SCommentTime = styled.span`
+  font-size: 1rem;
+  vertical-align: top;
+  color: ${({ theme }) => theme.color.LIGHT_GRAY};
+
+  &:before {
+    content: 'ㆍ';
+    padding-left: 0.6rem;
+  }
+`;
+
+const SProfileImg = styled.img`
+  width: 3.6rem;
+`;
+
+const SVerticalImg = styled.img`
+  width: 2rem;
+`;
+
+const SComments = styled.p`
+  margin: 0.4rem 4.8rem 0;
+  font-size: 1.4rem;
+`;
+
+function CommentItem() {
+  return (
+    <SContents>
+      <SCommentsInfo>
+        <SProfileImg src={basicProfilSmallImg} alt="프로필 이미지" />
+        <SUserInfo>
+          userId
+          <SCommentTime>5분 전</SCommentTime>
+        </SUserInfo>
+        <button type="button">
+          <SVerticalImg src={verticalIcon} alt="댓글 설정 버튼" />
+        </button>
+      </SCommentsInfo>
+      <SComments>comments</SComments>
+    </SContents>
+  );
+}
+
+export default CommentItem;

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -26,7 +26,7 @@ const SCommentTime = styled.span`
   vertical-align: top;
   color: ${({ theme }) => theme.color.LIGHT_GRAY};
 
-  &:before {
+  &::before {
     content: 'ㆍ';
     padding-left: 0.6rem;
   }

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -1,7 +1,52 @@
 import React from 'react';
+import styled from 'styled-components';
+
+import BaseHeader from '../../../components/common/BaseHeader';
+import CommentItem from '../../../components/Comment/CommentItem';
+import CommentInput from '../../../components/Comment/CommentInput';
+import { IR } from '../../../styles/Util';
+
+import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
+import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
+
+const STitle = styled.h2`
+  ${IR}
+`;
+
+const SContents = styled.section`
+  height: 110vh;
+  font-size: 1.4rem;
+`;
+
+const SPost = styled.div`
+  height: 45rem;
+  background-color: tomato;
+`;
+
+const SDividingLine = styled.div`
+  height: 1px;
+  margin: 2.2rem 1.6rem;
+  background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
 
 function PostDetail() {
-  return <div>PostDetail</div>;
+  return (
+    <>
+      <BaseHeader
+        leftIcon={arrowIcon}
+        rightIcon={verticalIcon}
+        rightClick={() => {}}
+        rightAlt="포스트 설정 버튼"
+      />
+      <SContents>
+        <STitle>게시물 상세 페이지</STitle>
+        <SPost />
+        <SDividingLine />
+        <CommentItem />
+      </SContents>
+      <CommentInput />
+    </>
+  );
 }
 
 export default PostDetail;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일
  - 헤더 추가
  - Post 컴포넌트 대체 요소 생성
  - 댓글 입력 컴포넌트 구현
  - 댓글 컴포넌트 구현

## 💬 전달사항
- 홈 페이지의 PostItem 수정 완료 후, 해당 페이지의 Post 컴포넌트 추가할 예정입니다.


## 💬 스크린샷
![스크린샷 2022-12-14 11 47 44](https://user-images.githubusercontent.com/74060716/207493032-ccc20985-990e-45ba-b0bc-fb0279bee2b8.png)
- 아래로 스크롤하면 댓글 하단 여백 보입니다!

## 💬 Issue Number
close : #25
