### PR TITLE
팔로워 페이지 UI 수정

### DIFF
--- a/src/components/FollowerItem/dummyList.js
+++ b/src/components/FollowerItem/dummyList.js
@@ -1,0 +1,40 @@
+const dummyList = [
+  {
+    id: 'test',
+    username: 'test',
+    accountname: 'test',
+    intro: 'Hello world!',
+    image: 'https://picsum.photos/250/250',
+    isfollow: true,
+  },
+  {
+    id: 'test2',
+    username: 'test2',
+    accountname: 'test2',
+    intro: 'Bye world!',
+    image: 'https://picsum.photos/250/250',
+    isfollow: false,
+  },
+  {
+    id: 'test3',
+    username:
+      '이름이길며어어어어어어어어어어어어어어어어어어어어어어어어어어언',
+    accountname: 'test3',
+    intro:
+      '소개가길며어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어언',
+    image: 'https://picsum.photos/250/250',
+    isfollow: false,
+  },
+  {
+    id: 'test4',
+    username:
+      '이름이길며어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어언',
+    accountname: 'test4',
+    intro:
+      '소개가길며어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어언',
+    image: 'https://picsum.photos/250/250',
+    isfollow: false,
+  },
+];
+
+export default dummyList;

--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Button from '../common/Button';
+import { FOLLOW_BUTTON } from '../../constants/buttonStyle';
+
+import { slEllipsis } from '../../styles/Util';
+
+const SContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.6rem;
+`;
+
+const SUserInfo = styled.div`
+  width: 65%;
+  margin: 0 1.2rem;
+`;
+
+const SImg = styled.img`
+  width: 5rem;
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+const SUserId = styled.p`
+  flex: 4 4 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.4rem;
+  ${slEllipsis}
+`;
+
+const SUserIntroduction = styled.p`
+  flex: 4 4 0;
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.color.GRAY};
+  ${slEllipsis}
+`;
+
+const SButton = styled(Button)`
+  flex: 1 1 0;
+  white-space: nowrap;
+`;
+
+function FollowerItem({ username, intro, image, state }) {
+  return (
+    <SContent>
+      <SImg src={image} alt="프로필 이미지" />
+      <SUserInfo>
+        <SUserId>{username}</SUserId>
+        <SUserIntroduction>{intro}</SUserIntroduction>
+      </SUserInfo>
+      {state === '취소' ? (
+        <SButton text={state} buttonStyle={FOLLOW_BUTTON} cancel />
+      ) : (
+        <SButton text={state} buttonStyle={FOLLOW_BUTTON} />
+      )}
+    </SContent>
+  );
+}
+
+export default FollowerItem;

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import BaseHeader from '../../../components/common/BaseHeader';
-import Button from '../../../components/common/Button';
-import { FOLLOW_BUTTON } from '../../../constants/buttonStyle';
+import FollowerItem from '../../../components/FollowerItem';
 
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
-import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
-import { IR, slEllipsis } from '../../../styles/Util';
+import { IR } from '../../../styles/Util';
+import dummyList from '../../../components/FollowerItem/dummyList';
 
 const SContainer = styled.section`
   padding: 24px 16px 0;
@@ -16,97 +15,31 @@ const STitle = styled.h2`
   ${IR}
 `;
 
-const SContent = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 1.6rem;
-  align-items: center;
-`;
-
-const STextItem = styled.div`
-  margin: 0 1.2rem;
-`;
-
-const SImg = styled.img`
-  width: 5rem;
-`;
-
-const STextUserId = styled.p`
-  width: 22.8rem;
-  margin-bottom: 0.6rem;
-  font-size: 1.4rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const STextIntroduction = styled.p`
-  width: 22.8rem;
-  font-size: 1.2rem;
-  color: ${({ theme }) => theme.color.GRAY};
-  ${slEllipsis}
-`;
-
 function Follower() {
   return (
     <div>
       <BaseHeader leftIcon={arrowIcon} title="Follower" />
       <SContainer>
         <STitle>팔로워 페이지</STitle>
-        <SContent>
-          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
-          <STextItem>
-            <STextUserId>
-              안녕하세요, 사용자 이름입니다. 이러쿵 저러쿵 어쩌고 저쩌고
-            </STextUserId>
-            <STextIntroduction>
-              안녕하세요, 제 소개를 하자면요. 이러쿵 저러쿵 어쩌고 저쩌고
-            </STextIntroduction>
-          </STextItem>
-          <Button text="팔로우" buttonStyle={FOLLOW_BUTTON} />
-        </SContent>
-
-        <SContent>
-          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
-          <STextItem>
-            <STextUserId>userId</STextUserId>
-            <STextIntroduction>Hello, world!</STextIntroduction>
-          </STextItem>
-          <Button
-            text="팔로우"
-            buttonStyle={FOLLOW_BUTTON}
-            color="green"
-            background="pink"
-          />
-        </SContent>
-
-        <SContent>
-          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
-          <STextItem>
-            <STextUserId>
-              안녕하세요, 사용자 이름입니다. 이러쿵 저러쿵 어쩌고 저쩌고
-            </STextUserId>
-            <STextIntroduction>
-              안녕하세요, 제 소개를 하자면요. 이러쿵 저러쿵 어쩌고 저쩌고
-            </STextIntroduction>
-          </STextItem>
-          <Button cancel text="취소" buttonStyle={FOLLOW_BUTTON} />
-        </SContent>
-
-        <SContent>
-          <SImg src={basicProfilSmallImg} alt="프로필 이미지" />
-          <STextItem>
-            <STextUserId>userId</STextUserId>
-            <STextIntroduction>Hello, world!</STextIntroduction>
-          </STextItem>
-          <Button
-            cancel
-            text="취소"
-            buttonStyle={FOLLOW_BUTTON}
-            color="green"
-            background="pink"
-          />
-        </SContent>
+        {dummyList.map((item) =>
+          item.isfollow ? (
+            <FollowerItem
+              key={item.id}
+              username={item.username}
+              intro={item.intro}
+              image={item.image}
+              state="취소"
+            />
+          ) : (
+            <FollowerItem
+              key={item.id}
+              username={item.username}
+              intro={item.intro}
+              image={item.image}
+              state="팔로우"
+            />
+          )
+        )}
       </SContainer>
     </div>
   );


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일 : 
  - 팔로워 아이템 컴포넌트 분리
  - 팔로워 페이지 및 팔로워 아이템 마크업 수정
    - 반응성을 고려하여 팔로워 아이템 마크업 수정
    - 더미데이터 사용

## 💬 스크린샷
<img width="376" alt="스크린샷 2022-12-14 15 24 25" src="https://user-images.githubusercontent.com/74060716/207522817-9950e402-4ae8-4e66-b133-5733aeaa8e44.png">
<img width="403" alt="스크린샷 2022-12-14 15 23 55" src="https://user-images.githubusercontent.com/74060716/207522826-543d1970-19d4-4375-bc55-7aaf3bbd1e40.png">
<img width="1440" alt="스크린샷 2022-12-14 15 23 33" src="https://user-images.githubusercontent.com/74060716/207522851-02062cbc-e3c6-4486-ab58-56ce98cc4bf6.png">


## 💬 Issue Number
close : #32
