### PR TITLE
Feature/#34 404 페이지 UI 

### DIFF
--- a/src/components/MessageItem/index.jsx
+++ b/src/components/MessageItem/index.jsx
@@ -49,15 +49,14 @@ const SUploadedImgContainer = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius.BASE};
 `;
 
+const SUploadedImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+`;
+
 function MessageItem({ text, time, img }) {
-  const SUploadedImg = styled.img.attrs({
-    src: `${img}`,
-  })`
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: ${({ theme }) => theme.borderRadius.BASE};
-  `;
   return (
     <SMessageItem>
       <SProfileImg />

--- a/src/components/MessageItemYours/index.jsx
+++ b/src/components/MessageItemYours/index.jsx
@@ -36,15 +36,14 @@ const SUploadedImgContainer = styled.div`
   overflow: hidden;
 `;
 
-function MessageItem({ text, time, img }) {
-  const SUploadedImg = styled.img.attrs({
-    src: `${img}`,
-  })`
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: ${({ theme }) => theme.borderRadius.BASE};
-  `;
+const SUploadedImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+`;
+
+function MessageItemYours({ text, time, img }) {
   return (
     <SMessageItemYours>
       {img ? (
@@ -59,4 +58,4 @@ function MessageItem({ text, time, img }) {
   );
 }
 
-export default MessageItem;
+export default MessageItemYours;

--- a/src/pages/404/index.jsx
+++ b/src/pages/404/index.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from '../../components/common/Button';
+import { LARGE_BUTTON } from '../../constants/buttonStyle';
+import ErrorImg from '../../assets/404_img.png';
+
+const SContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1rem;
+`;
+
+const SButton = styled(Button)`
+  width: 25%;
+`;
+
+const Stext = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
+const SUploadedImg = styled.img`
+  width: 22rem;
+  object-fit: cover;
+`;
+
+function NotFound() {
+  return (
+    <SContainer>
+      <SUploadedImg src={ErrorImg} />
+      <Stext>페이지를 찾을 수 없습니다. :&#40; </Stext>
+      <SButton buttonStyle={LARGE_BUTTON} text="이전 페이지" />
+    </SContainer>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일 :  404페이지 UI 구현


## 💬 기대 결과
- 404페이지 UI 구현

## 💬 전달사항
- 피그마상으로는 살짝 위로 배치되어있는데 가운데 정렬로 바꿨습니다.
- 다시는 이슈넘버를 빼먹지 않겠습니다. 


## 💬 스크린샷
<img width="372" alt="스크린샷 2022-12-14 18 10 56" src="https://user-images.githubusercontent.com/95897068/207554285-ec6edb87-8230-4363-8de1-ecb6aa668bae.png">

<img width="834" alt="스크린샷 2022-12-14 18 11 18" src="https://user-images.githubusercontent.com/95897068/207554360-4be10d6e-3b9f-413b-bfee-050fbefef5cc.png">
(화면이 늘어나도 문제없다구~)

## 💬 Issue Number
close : #34
