### PR TITLE
게시글 상세 페이지 UI 수정 및 모달창 기능 구현

### DIFF
--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import BottomSheet from '../../Modal/BottomSheet';
+import BottomSheetContent from '../../Modal/BottomSheet/BottomSheetContent';
 
 import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
 import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
@@ -46,6 +48,13 @@ const SComments = styled.p`
 `;
 
 function CommentItem() {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const handleBottomSheetOpen = (e) => {
+    e.stopPropagation();
+    setIsBottomSheetOpen(!isBottomSheetOpen);
+  };
+
   return (
     <SContents>
       <SCommentsInfo>
@@ -54,9 +63,16 @@ function CommentItem() {
           userId
           <SCommentTime>5분 전</SCommentTime>
         </SUserInfo>
-        <button type="button">
+        <button type="button" onClick={handleBottomSheetOpen}>
           <SVerticalImg src={verticalIcon} alt="댓글 설정 버튼" />
         </button>
+        {isBottomSheetOpen && (
+          <BottomSheet handleClose={handleBottomSheetOpen}>
+            {/* 로그인 한 경우(내 댓글인 경우) => 삭제 아니면 신고하기 */}
+            <BottomSheetContent text="신고하기" />
+            <BottomSheetContent text="신고하기" />
+          </BottomSheet>
+        )}
       </SCommentsInfo>
       <SComments>comments</SComments>
     </SContents>

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -38,7 +38,7 @@ const SProfileImg = styled.img`
   width: 3.6rem;
 `;
 
-const SVerticalImg = styled.img`
+const SVerticalButton = styled.button`
   width: 2rem;
 `;
 
@@ -63,9 +63,9 @@ function CommentItem() {
           userId
           <SCommentTime>5분 전</SCommentTime>
         </SUserInfo>
-        <button type="button" onClick={handleBottomSheetOpen}>
-          <SVerticalImg src={verticalIcon} alt="댓글 설정 버튼" />
-        </button>
+        <SVerticalButton type="button" onClick={handleBottomSheetOpen}>
+          <img src={verticalIcon} alt="댓글 설정 버튼" />
+        </SVerticalButton>
         {isBottomSheetOpen && (
           <BottomSheet handleClose={handleBottomSheetOpen}>
             {/* 로그인 한 경우(내 댓글인 경우) => 삭제 아니면 신고하기 */}

--- a/src/components/Post/PostItem/index.jsx
+++ b/src/components/Post/PostItem/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import profileImg from '../../../assets/basic-profile_small.png';
 import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
@@ -16,6 +16,12 @@ const SPostItem = styled.li`
   padding: 1.4rem;
   border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   border-radius: 1rem;
+
+  ${({ detail }) =>
+    detail &&
+    css`
+      border: none;
+    `}
 `;
 
 const SUserInfoContainer = styled.div`
@@ -50,6 +56,13 @@ const SContents = styled.div`
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
 
   margin-bottom: 1.4rem;
+
+  ${({ detail }) =>
+    detail &&
+    css`
+      overflow: auto;
+      display: block;
+    `}
 `;
 
 const STagList = styled.ul`
@@ -128,6 +141,7 @@ function PostItem({
   commentCount,
   author,
   goPostDetailPage,
+  detail,
 }) {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
@@ -138,7 +152,10 @@ function PostItem({
 
   return (
     <>
-      <SPostItem onClick={() => goPostDetailPage(postId)}>
+      <SPostItem
+        detail={detail}
+        onClick={() => (detail ? null : goPostDetailPage(postId))}
+      >
         <SUserInfoContainer>
           <img src={profileImg} alt="프로필 이미지" />
           <STextBox>
@@ -146,7 +163,7 @@ function PostItem({
             <SAccountName>{author.accountname}</SAccountName>
           </STextBox>
         </SUserInfoContainer>
-        <SContents>
+        <SContents detail={detail}>
           <STagList>
             <STagItem>#메리마스메리크리스ㅁㅇㄴㅁㄴ마스메리크리스마스</STagItem>
             <STagItem>#메리크스</STagItem>
@@ -175,9 +192,11 @@ function PostItem({
           </SIConContainer>
           <SDate>{createdAt}</SDate>
         </SBottomContainer>
-        <SVerticalButton onClick={handleBottomSheetOpen}>
-          <img src={verticalIcon} alt="포스트 설정 버튼" />
-        </SVerticalButton>
+        {!detail && (
+          <SVerticalButton onClick={handleBottomSheetOpen}>
+            <img src={verticalIcon} alt="포스트 설정 버튼" />
+          </SVerticalButton>
+        )}
       </SPostItem>
       {isBottomSheetOpen && (
         <BottomSheet handleClose={handleBottomSheetOpen}>

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import BaseHeader from '../../../components/common/BaseHeader';
@@ -10,6 +10,8 @@ import { IR } from '../../../styles/Util';
 
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
+import BottomSheet from '../../../components/Modal/BottomSheet';
+import BottomSheetContent from '../../../components/Modal/BottomSheet/BottomSheetContent';
 
 const STitle = styled.h2`
   ${IR}
@@ -27,14 +29,28 @@ const SDividingLine = styled.div`
 `;
 
 function PostDetail() {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const handleBottomSheetOpen = (e) => {
+    e.stopPropagation();
+    setIsBottomSheetOpen(!isBottomSheetOpen);
+  };
+
   return (
     <>
       <BaseHeader
         leftIcon={arrowIcon}
         rightIcon={verticalIcon}
-        rightClick={() => {}}
+        rightClick={handleBottomSheetOpen}
         rightAlt="포스트 설정 버튼"
       />
+      {isBottomSheetOpen && (
+        <BottomSheet handleClose={handleBottomSheetOpen}>
+          {/* 로그인 한 경우(내 글인 경우) => 삭제, 수정, 아니면 신고하기 */}
+          <BottomSheetContent text="신고하기" />
+          <BottomSheetContent text="신고하기" />
+        </BottomSheet>
+      )}
 
       <SContents>
         <STitle>게시물 상세 페이지</STitle>

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import BaseHeader from '../../../components/common/BaseHeader';
+import BottomSheet from '../../../components/Modal/BottomSheet';
+import BottomSheetContent from '../../../components/Modal/BottomSheet/BottomSheetContent';
 import PostItem from '../../../components/Post/PostItem';
 import dummyList from '../../../components/Post/dummyList';
 import CommentItem from '../../../components/Comment/CommentItem';
@@ -10,8 +12,6 @@ import { IR } from '../../../styles/Util';
 
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
-import BottomSheet from '../../../components/Modal/BottomSheet';
-import BottomSheetContent from '../../../components/Modal/BottomSheet/BottomSheetContent';
 
 const STitle = styled.h2`
   ${IR}

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import BaseHeader from '../../../components/common/BaseHeader';
+import PostItem from '../../../components/Post/PostItem';
+import dummyList from '../../../components/Post/dummyList';
 import CommentItem from '../../../components/Comment/CommentItem';
 import CommentInput from '../../../components/Comment/CommentInput';
 import { IR } from '../../../styles/Util';
@@ -16,11 +18,6 @@ const STitle = styled.h2`
 const SContents = styled.section`
   height: 110vh;
   font-size: 1.4rem;
-`;
-
-const SPost = styled.div`
-  height: 45rem;
-  background-color: tomato;
 `;
 
 const SDividingLine = styled.div`
@@ -38,12 +35,26 @@ function PostDetail() {
         rightClick={() => {}}
         rightAlt="포스트 설정 버튼"
       />
+
       <SContents>
         <STitle>게시물 상세 페이지</STitle>
-        <SPost />
+        {/* 현재 주소에서 유저 아이디만 잘라서 가져와 게시물 상세 페이지 보여주기 */}
+        <PostItem
+          key={dummyList[0].id}
+          postId={dummyList[0].id}
+          content={dummyList[0].content}
+          author={dummyList[0].author}
+          image={dummyList[0].image}
+          hearted={dummyList[0].hearted}
+          heartedCount={dummyList[0].heartedCount}
+          commentCount={dummyList[0].commentCount}
+          createdAt={dummyList[0].createdAt}
+          detail
+        />
         <SDividingLine />
         <CommentItem />
       </SContents>
+
       <CommentInput />
     </>
   );

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -16,7 +16,7 @@ const STitle = styled.h2`
 `;
 
 const SContents = styled.section`
-  height: 110vh;
+  height: 115vh;
   font-size: 1.4rem;
 `;
 

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -82,6 +82,10 @@ const GlobalStyle = createGlobalStyle`
     box-shadow: none;
     resize: none; 
   }
+
+  li {
+    list-style: none;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 게시글/댓글 우측의 더보기 버튼을 눌렀을 때 모달창 이벤트
- [x] 마크업 & 스타일 : 게시글의 경우, 홈 페이지에서 구현된 컴포넌트 스타일을 가져와 스타일을 변경하여 구현

## 💬 전달사항
- 홈 페이지에서 게시물 상세 페이지로 이동했을 때, 스크롤 위치가 매번 다른 것 같아서 항상 상단으로 올 수 있도록 나중에 기능 구현해보겠습니다!

## 💬 스크린샷
![스크린샷 2022-12-15 09 45 03](https://user-images.githubusercontent.com/74060716/207746189-4a5f6fc7-f18a-4c20-8f1e-ce7f4931c78c.png)
![스크린샷 2022-12-15 09 45 14](https://user-images.githubusercontent.com/74060716/207746198-f30c63b5-be25-4751-a1e4-9ab175f6fa7f.png)
![스크린샷 2022-12-15 09 45 27](https://user-images.githubusercontent.com/74060716/207746200-5e1acab1-e72f-43c2-a4e1-60a472727296.png)



## 💬 Issue Number
close : #38 
