### PR TITLE
채팅 목록 UI 구현 및 기능 추가 

### DIFF
--- a/src/components/UserItem/index.jsx
+++ b/src/components/UserItem/index.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { slEllipsis } from '../../styles/Util';
+
+const SContent = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.6rem;
+`;
+
+const SUserInfo = styled.div`
+  width: 65%;
+  margin: 0 1.2rem;
+`;
+
+const SImg = styled.img`
+  position: relative;
+  width: 4.2rem;
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+const SUserId = styled.p`
+  flex: 4 4 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.4rem;
+  ${slEllipsis}
+`;
+
+const SText = styled.p`
+  flex: 4 4 0;
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.color.GRAY};
+  ${slEllipsis}
+`;
+
+const SDate = styled.p`
+  font-size: 1rem;
+  color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  margin-top: 2.5rem;
+`;
+
+function UserItem({ username, text, image, date }) {
+  return (
+    <SContent>
+      <SImg src={image} alt="프로필 이미지" />
+      <SUserInfo>
+        <SUserId>{username}</SUserId>
+        <SText>{text}</SText>
+      </SUserInfo>
+      {date && <SDate>{date}</SDate>}
+    </SContent>
+  );
+}
+
+export default UserItem;

--- a/src/components/UserItem/index.jsx
+++ b/src/components/UserItem/index.jsx
@@ -14,6 +14,21 @@ const SUserInfo = styled.div`
   margin: 0 1.2rem;
 `;
 
+const SUserInfoActive = styled.div`
+  width: 65%;
+  margin: 0 1.2rem;
+  &::before {
+    content: '';
+    z-index: 99;
+    position: absolute;
+    left: 1.6rem;
+    width: 1.2rem;
+    height: 1.2rem;
+    background-color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+    border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+  }
+`;
+
 const SImg = styled.img`
   position: relative;
   width: 4.2rem;
@@ -40,14 +55,21 @@ const SDate = styled.p`
   margin-top: 2.5rem;
 `;
 
-function UserItem({ username, text, image, date }) {
+function UserItem({ username, text, image, date, isActive }) {
   return (
     <SContent>
       <SImg src={image} alt="프로필 이미지" />
-      <SUserInfo>
-        <SUserId>{username}</SUserId>
-        <SText>{text}</SText>
-      </SUserInfo>
+      {isActive ? (
+        <SUserInfoActive>
+          <SUserId>{username}</SUserId>
+          <SText>{text}</SText>
+        </SUserInfoActive>
+      ) : (
+        <SUserInfo>
+          <SUserId>{username}</SUserId>
+          <SText>{text}</SText>
+        </SUserInfo>
+      )}
       {date && <SDate>{date}</SDate>}
     </SContent>
   );

--- a/src/pages/Chat/ChatDetail/index.jsx
+++ b/src/pages/Chat/ChatDetail/index.jsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import BaseHeader from '../../../components/common/BaseHeader';
 import MessageItem from '../../../components/MessageItem';
 import MessageItemYours from '../../../components/MessageItemYours';
 import leftIcon from '../../../assets/icon/icon-arrow-left.png';
 import rightIcon from '../../../assets/icon/s-icon-more-vertical.png';
 import MessageInputBar from '../../../components/MessageInput';
+import BottomSheet from '../../../components/Modal/BottomSheet';
+import BottomSheetContent from '../../../components/Modal/BottomSheet/BottomSheetContent';
 
 const SContainer = styled.div`
   background-color: #f2f2f2;
@@ -37,9 +40,34 @@ const dummyImg = 'https://via.placeholder.com/240x240/D9D9D9/000000';
 const nickName = '사용자 닉네임';
 
 function ChatDetail() {
+  const navigate = useNavigate();
+  const leftClick = () => {
+    navigate(`/Chat`);
+  };
+
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const handleBottomSheetOpen = (e) => {
+    e.stopPropagation();
+    setIsBottomSheetOpen(!isBottomSheetOpen);
+  };
+
   return (
     <SContainer>
-      <BaseHeader leftIcon={leftIcon} title={nickName} rightIcon={rightIcon} />
+      <BaseHeader
+        leftIcon={leftIcon}
+        title={nickName}
+        leftClick={leftClick}
+        rightIcon={rightIcon}
+        rightClick={handleBottomSheetOpen}
+      />
+      {isBottomSheetOpen && (
+        <BottomSheet handleClose={handleBottomSheetOpen}>
+          <BottomSheetContent text="신고하기" />
+          <BottomSheetContent text="신고하기" />
+        </BottomSheet>
+      )}
+
       <SMessageList>
         <MessageItem text={dummyText.message1} time={dummyTime.time1} />
         <MessageItem img={dummyImg} time={dummyTime.time2} />

--- a/src/pages/Chat/index.jsx
+++ b/src/pages/Chat/index.jsx
@@ -22,6 +22,10 @@ function Chat() {
     navigate(`/home`);
   };
 
+  const usernameClick = () => {
+    navigate(`/chat/:id`);
+  };
+
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
   const handleBottomSheetOpen = (e) => {
@@ -38,12 +42,11 @@ function Chat() {
       />
       {isBottomSheetOpen && (
         <BottomSheet handleClose={handleBottomSheetOpen}>
-          {/* 로그인 한 경우(내 글인 경우) => 삭제, 수정, 아니면 신고하기 */}
           <BottomSheetContent text="편집" />
           <BottomSheetContent text="채팅방 정렬" />
         </BottomSheet>
       )}
-      <SContainer>
+      <SContainer onClick={usernameClick}>
         <UserItem
           username="유저 닉네임"
           text="이곳에는 가장 최근 채팅 내용이 들어갑니당"

--- a/src/pages/Chat/index.jsx
+++ b/src/pages/Chat/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import Navigation from '../../components/common/Navigation';
@@ -7,6 +7,8 @@ import leftIcon from '../../assets/icon/icon-arrow-left.png';
 import rightIcon from '../../assets/icon/s-icon-more-vertical.png';
 import profile from '../../assets/basic-profile_small.png';
 import UserItem from '../../components/UserItem';
+import BottomSheet from '../../components/Modal/BottomSheet';
+import BottomSheetContent from '../../components/Modal/BottomSheet/BottomSheetContent';
 
 const SContainer = styled.div`
   padding: 2.4rem 1.6rem;
@@ -20,13 +22,27 @@ function Chat() {
     navigate(`/home`);
   };
 
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const handleBottomSheetOpen = (e) => {
+    e.stopPropagation();
+    setIsBottomSheetOpen(!isBottomSheetOpen);
+  };
   return (
     <div>
       <BaseHeader
         leftIcon={leftIcon}
         rightIcon={rightIcon}
         leftClick={leftClick}
+        rightClick={handleBottomSheetOpen}
       />
+      {isBottomSheetOpen && (
+        <BottomSheet handleClose={handleBottomSheetOpen}>
+          {/* 로그인 한 경우(내 글인 경우) => 삭제, 수정, 아니면 신고하기 */}
+          <BottomSheetContent text="편집" />
+          <BottomSheetContent text="채팅방 정렬" />
+        </BottomSheet>
+      )}
       <SContainer>
         <UserItem
           username="유저 닉네임"
@@ -55,6 +71,7 @@ function Chat() {
           date={DummyDate}
         />
       </SContainer>
+
       <Navigation />
     </div>
   );

--- a/src/pages/Chat/index.jsx
+++ b/src/pages/Chat/index.jsx
@@ -1,8 +1,63 @@
 import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import Navigation from '../../components/common/Navigation';
+import BaseHeader from '../../components/common/BaseHeader';
+import leftIcon from '../../assets/icon/icon-arrow-left.png';
+import rightIcon from '../../assets/icon/s-icon-more-vertical.png';
+import profile from '../../assets/basic-profile_small.png';
+import UserItem from '../../components/UserItem';
+
+const SContainer = styled.div`
+  padding: 2.4rem 1.6rem;
+`;
+
+const DummyDate = '22.12.15';
 
 function Chat() {
-  return <Navigation />;
+  const navigate = useNavigate();
+  const leftClick = () => {
+    navigate(`/home`);
+  };
+
+  return (
+    <div>
+      <BaseHeader
+        leftIcon={leftIcon}
+        rightIcon={rightIcon}
+        leftClick={leftClick}
+      />
+      <SContainer>
+        <UserItem
+          username="유저 닉네임"
+          text="이곳에는 가장 최근 채팅 내용이 들어갑니당"
+          image={profile}
+          date={DummyDate}
+          isActive
+        />
+        <UserItem
+          username="예를들면 애월읍 위니브 감귤농장"
+          text="이곳에는 가장 최근 채팅 내용이 들어갑니당"
+          image={profile}
+          date={DummyDate}
+          isActive
+        />
+        <UserItem
+          username="애월읍 위니브 감귤농장2"
+          text="이곳에는 가장 최근 채팅 내용이 들어갑니당"
+          image={profile}
+          date={DummyDate}
+        />
+        <UserItem
+          username="애월읍 위니브 감귤농장3"
+          text="이곳에는 가장 최근 채팅 내용이 들어갑니당"
+          image={profile}
+          date={DummyDate}
+        />
+      </SContainer>
+      <Navigation />
+    </div>
+  );
 }
 
 export default Chat;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [x] 마크업 & 스타일 : 채팅 목록 UI 구현 
- [x] 기능 추가 : 채팅 목록, 채팅방 뒤로가기 및 모달 버튼 활성화 

## 💬 기대 결과

- 뒤로가기 버튼 활성화로 페이지 탐색이 용이해질 것 
- 채팅 목록, 채팅방 양옆 버튼들이 제 기능을 함

## 💬 전달사항

- 모바일임을 고려해서, 채팅 목록에서 뒤로 가기 버튼을 눌렀을 때 바로 이전 작업으로 돌아가는 것보다는 홈으로 이동하는게 자연스럽지 않을까 생각해서 홈으로 이동하도록 했습니다. 
- 피그마에서는 우측 상단 더보기버튼 클릭 => 모달창 팝업 => 채팅방 나가기 클릭 이런 순서를 밟아야 나가지도록 되어 있는데 부자연스럽고 불편할 것 같아서 뒤로가기 기능 하나로 통합하고, 더보기는 신고하기로 대체하였습니다. 
- 모달 로직 있는 것 그대로 퍼왔습니다 ~ ㅎㅎㅎ 
- UserItem 컴포넌트를 생성했는데 서치 목록에서도 쓸 수 있을 것이라 생각합니다. (피그마의 search-2) 

<img width="322" alt="스크린샷 2022-12-15 20 17 19" src="https://user-images.githubusercontent.com/95897068/207845926-736d9cc4-8707-4db4-bb29-9cd21d236cf1.png">

- 🐛 채팅 목록에서 뒤로가기를 눌러 홈으로 이동했을 때 하단 탭바에 채팅이 Active 표시로 되어있는  버그 발견 


## 💬 스크린샷

https://user-images.githubusercontent.com/95897068/207845607-e4c7f8b9-d193-4471-9574-14f72725e6b8.mov

## 💬 Issue Number
close : #45
