### PR TITLE
로그인 페이지 UI 작업

### DIFF
--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -15,7 +15,7 @@ function checkValid(signUpValid, inputValue) {
   }
 
   return css`
-    border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+    border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
   `;
 }
 

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -48,7 +48,7 @@ const WarningMessage = styled.p`
   margin-top: 0.5rem;
 `;
 
-function FormInput({
+function AuthInputForm({
   id,
   label,
   inputProps,
@@ -75,4 +75,4 @@ function FormInput({
   );
 }
 
-export default FormInput;
+export default AuthInputForm;

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -2,20 +2,20 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 function checkValid(signUpValid, inputValue) {
-  if (inputValue.length === 0) {
+  if (inputValue?.length === 0) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
     `;
   }
 
-  if (!signUpValid && inputValue.length > 0) {
+  if (!signUpValid && inputValue?.length > 0) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.RED};
     `;
   }
 
   return css`
-    border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
+    border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   `;
 }
 

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,7 +1,64 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import AuthInputForm from '../../../components/AuthInputForm';
+import Button from '../../../components/common/Button';
+import { LARGE_BUTTON } from '../../../constants/buttonStyle';
+import Title from '../../../components/Title';
+
+const SContainer = styled.div`
+  padding: 3.4rem;
+  height: 100vh;
+`;
+
+const SFormContainer = styled.form`
+  margin-top: 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+`;
+
+const LoginButton = styled(Button)`
+  margin-top: 5rem;
+`;
+
+const SLink = styled(Link)`
+  display: block;
+  text-align: center;
+  color: ${({ theme }) => theme.color.GRAY};
+  margin-top: 2rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
 
 function Login() {
-  return <div>Login</div>;
+  return (
+    <SContainer>
+      <Title>로그인</Title>
+      <SFormContainer>
+        <AuthInputForm
+          id="email"
+          label="이메일"
+          inputProps={{
+            type: 'email',
+            placeholder: '이메일을 입력해주세요',
+          }}
+        />
+        <AuthInputForm
+          id="password"
+          label="비밀번호"
+          inputProps={{
+            type: 'password',
+            placeholder: '비밀번호를 입력해주세요',
+          }}
+        />
+        <LoginButton text="로그인" buttonStyle={LARGE_BUTTON} />
+      </SFormContainer>
+      <SLink to="/signup">이메일로 회원가입</SLink>
+    </SContainer>
+  );
 }
 
 export default Login;

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import emailValidAxios from '../../../api/emailValidAxios';
 
 import Title from '../../../components/Title';
-import FormInput from '../../../components/FormInput';
+import AuthInputForm from '../../../components/AuthInputForm';
 import Button from '../../../components/common/Button';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 import { signUpEmail, signUpPassword } from '../../../atoms/auth';
@@ -130,7 +130,7 @@ function SignUp() {
         이메일로 회원가입
       </Title>
       <FormContainer>
-        <FormInput
+        <AuthInputForm
           id="email"
           label="이메일"
           inputProps={{
@@ -142,7 +142,7 @@ function SignUp() {
           inputValue={signUpEmailValue}
           warningMsg={emailWarningMsg}
         />
-        <FormInput
+        <AuthInputForm
           id="password"
           label="비밀번호"
           inputProps={{
@@ -155,7 +155,7 @@ function SignUp() {
           inputValue={signUpPasswordValue}
           warningMsg={pwWarningMsg}
         />
-        <FormInput
+        <AuthInputForm
           id="confirmPassword"
           label="비밀번호 확인"
           inputProps={{


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 로그인 페이지 마크업


## 💬 기대 결과
- 피그마 디자인 시안대로 UI 구현

## 💬 전달사항
- 디자인 작업 때문에 AuthInputForm에서 작성한 checkValid 함수가 <AuthInputForm /> 컴포넌트에 props로 inputValue를 주지 않으면 최초 랜더링 시 언디파인드 뿜어내서 에러로 인해 일단 옵셔널체이닝으로 임시방편 해놓았습니다.
-  checkValid 함수 기본 리턴값의 컬러가 ACTIVE_BLUE로 되어있어서 아무것도 입력하지 않았을 때 GRAY가 아닌 ACTIVE_BLUE 활성화
<img width="304" alt="스크린샷 2022-12-16 오후 6 45 24" src="https://user-images.githubusercontent.com/101461874/208072756-b9da8e72-cf6d-403a-a0dd-31082e30e4d3.png">
기능 구현하면서 수정해나갈 듯 합니다.

## 💬 스크린샷
일단 디자인 보여주기 위한 gif
![login_1](https://user-images.githubusercontent.com/101461874/208072654-a176b5a9-018f-4031-8e1b-156c8c10e698.gif)


## 💬 Issue Number
close : #50 
