### PR TITLE
로그인 페이지 기능구현

### DIFF
--- a/src/api/authAxios.js
+++ b/src/api/authAxios.js
@@ -2,6 +2,9 @@ import axios from 'axios';
 
 const authAxios = axios.create({
   baseURL: 'https://mandarin.api.weniv.co.kr/user',
+  headers: {
+    'Content-type': 'application/json',
+  },
 });
 
 export default authAxios;

--- a/src/atoms/auth.js
+++ b/src/atoms/auth.js
@@ -9,3 +9,13 @@ export const signUpPassword = atom({
   key: 'signUpPassword',
   default: '',
 });
+
+export const userEmail = atom({
+  key: 'userEmail',
+  default: '',
+});
+
+export const userPassword = atom({
+  key: 'userPassword',
+  default: '',
+});

--- a/src/atoms/auth.js
+++ b/src/atoms/auth.js
@@ -9,13 +9,3 @@ export const signUpPassword = atom({
   key: 'signUpPassword',
   default: '',
 });
-
-export const userEmail = atom({
-  key: 'userEmail',
-  default: '',
-});
-
-export const userPassword = atom({
-  key: 'userPassword',
-  default: '',
-});

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-function checkValid(signUpValid, inputValue, isWrong) {
+function checkValid(signUpValid, inputValue, isCorrect) {
   if (inputValue?.length === 0) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
     `;
   }
 
-  if (!signUpValid || inputValue?.length > 0 || isWrong) {
+  if (!signUpValid && inputValue?.length > 0 && !isCorrect) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.RED};
     `;
@@ -19,17 +19,6 @@ function checkValid(signUpValid, inputValue, isWrong) {
     border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
   `;
 }
-
-// function loginValid(isWrong) {
-//   if (isWrong) {
-//     return css`
-//       border: 1px solid ${({ theme }) => theme.color.RED};
-//     `;
-//   }
-//   return css`
-//     border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-//   `;
-// }
 
 const SContainer = styled.div``;
 
@@ -51,9 +40,9 @@ const Input = styled.input`
     color: ${({ theme }) => theme.color.LIGHT_GRAY};
   }
 
-  ${({ signUpValid, inputValue }) => checkValid(signUpValid, inputValue)}
+  ${({ signUpValid, inputValue, isCorrect }) =>
+    checkValid(signUpValid, inputValue, isCorrect)}
 `;
-/* ${({ isWrong }) => loginValid(isWrong)} */
 
 const WarningMessage = styled.p`
   position: absolute;
@@ -70,7 +59,7 @@ function AuthInputForm({
   handleLoginState,
   signUpValid,
   inputValue,
-  isWrong,
+  isCorrect,
 }) {
   const location = useLocation();
 
@@ -91,13 +80,14 @@ function AuthInputForm({
         {...inputProps}
         inputValue={inputValue}
         signUpValid={signUpValid}
+        isCorrect={isCorrect}
         onChange={setState}
         onKeyDown={setState}
       />
       {!signUpValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>
       )}
-      {isWrong && <WarningMessage>{warningMsg}</WarningMessage>}
+      {isCorrect && <WarningMessage>{warningMsg}</WarningMessage>}
     </SContainer>
   );
 }

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
@@ -60,6 +60,7 @@ function AuthInputForm({
   signUpValid,
   inputValue,
   isCorrect,
+  inputRef,
 }) {
   const location = useLocation();
 
@@ -78,6 +79,7 @@ function AuthInputForm({
       <Input
         id={id}
         {...inputProps}
+        ref={inputRef}
         inputValue={inputValue}
         signUpValid={signUpValid}
         isCorrect={isCorrect}

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -60,6 +60,16 @@ function AuthInputForm({
   inputValue,
 }) {
   const location = useLocation();
+
+  const setState = (e) => {
+    if (location.pathname === '/signup') {
+      handleSignUpState(e);
+    }
+    if (location.pathname === '/login') {
+      handleLoginState(e);
+    }
+  };
+
   return (
     <SContainer>
       <Label htmlFor={id}>{label}</Label>
@@ -68,22 +78,8 @@ function AuthInputForm({
         {...inputProps}
         inputValue={inputValue}
         signUpValid={signUpValid}
-        onChange={(e) => {
-          if (location.pathname === '/signup') {
-            handleSignUpState(e);
-          }
-          if (location.pathname === '/login') {
-            handleLoginState(e);
-          }
-        }}
-        onKeyDown={(e) => {
-          if (location.pathname === '/signup') {
-            handleSignUpState(e);
-          }
-          if (location.pathname === '/login') {
-            handleLoginState(e);
-          }
-        }}
+        onChange={setState}
+        onKeyDown={setState}
       />
       {!signUpValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
 function checkValid(signUpValid, inputValue) {
@@ -54,9 +55,11 @@ function AuthInputForm({
   inputProps,
   warningMsg,
   handleSignUpState,
+  handleLoginState,
   signUpValid,
   inputValue,
 }) {
+  const location = useLocation();
   return (
     <SContainer>
       <Label htmlFor={id}>{label}</Label>
@@ -65,8 +68,22 @@ function AuthInputForm({
         {...inputProps}
         inputValue={inputValue}
         signUpValid={signUpValid}
-        onChange={handleSignUpState}
-        onKeyDown={handleSignUpState}
+        onChange={(e) => {
+          if (location.pathname === '/signup') {
+            handleSignUpState(e);
+          }
+          if (location.pathname === '/login') {
+            handleLoginState(e);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (location.pathname === '/signup') {
+            handleSignUpState(e);
+          }
+          if (location.pathname === '/login') {
+            handleLoginState(e);
+          }
+        }}
       />
       {!signUpValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-function checkValid(signUpValid, inputValue) {
+function checkValid(signUpValid, inputValue, isWrong) {
   if (inputValue?.length === 0) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
     `;
   }
 
-  if (!signUpValid && inputValue?.length > 0) {
+  if (!signUpValid || inputValue?.length > 0 || isWrong) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.RED};
     `;
@@ -19,6 +19,17 @@ function checkValid(signUpValid, inputValue) {
     border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
   `;
 }
+
+// function loginValid(isWrong) {
+//   if (isWrong) {
+//     return css`
+//       border: 1px solid ${({ theme }) => theme.color.RED};
+//     `;
+//   }
+//   return css`
+//     border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+//   `;
+// }
 
 const SContainer = styled.div``;
 
@@ -42,6 +53,7 @@ const Input = styled.input`
 
   ${({ signUpValid, inputValue }) => checkValid(signUpValid, inputValue)}
 `;
+/* ${({ isWrong }) => loginValid(isWrong)} */
 
 const WarningMessage = styled.p`
   position: absolute;
@@ -58,6 +70,7 @@ function AuthInputForm({
   handleLoginState,
   signUpValid,
   inputValue,
+  isWrong,
 }) {
   const location = useLocation();
 
@@ -84,6 +97,7 @@ function AuthInputForm({
       {!signUpValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>
       )}
+      {isWrong && <WarningMessage>{warningMsg}</WarningMessage>}
     </SContainer>
   );
 }

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
 import AuthInputForm from '../../../components/AuthInputForm';
 import Button from '../../../components/common/Button';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 import Title from '../../../components/Title';
-import { userEmail, userPassword } from '../../../atoms/auth';
 import authAxios from '../../../api/authAxios';
 
 const SContainer = styled.div`
@@ -37,8 +35,8 @@ const SLink = styled(Link)`
 `;
 
 function Login() {
-  const [loginEmail, setLoginEmail] = useRecoilState(userEmail);
-  const [loginPassword, setLoginPassword] = useRecoilState(userPassword);
+  const [loginEmail, setLoginEmail] = useState('');
+  const [loginPassword, setLoginPassword] = useState('');
   const [isCorrect, setIsCorrect] = useState(true);
   const [loginWarningMsg, setLoginWarningMsg] = useState('');
   const [buttonNotAllow, setButtonNotAllow] = useState(true);

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import AuthInputForm from '../../../components/AuthInputForm';
 import Button from '../../../components/common/Button';
@@ -41,6 +41,8 @@ function Login() {
   const [loginWarningMsg, setLoginWarningMsg] = useState('');
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
+  const navigate = useNavigate();
+
   const handleLoginEmail = (e) => {
     setLoginEmail(e.target.value);
   };
@@ -69,6 +71,7 @@ function Login() {
 
         if (!res.data.message) {
           console.log(res.data);
+          navigate('/home');
         }
 
         if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -39,8 +39,7 @@ const SLink = styled(Link)`
 function Login() {
   const [loginEmail, setLoginEmail] = useRecoilState(userEmail);
   const [loginPassword, setLoginPassword] = useRecoilState(userPassword);
-  const [isEmail, setIsEmail] = useState(false);
-  const [isWrong, setIsWrong] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(true);
   const [loginWarningMsg, setLoginWarningMsg] = useState('');
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
@@ -62,15 +61,6 @@ function Login() {
     async (e) => {
       e.preventDefault();
 
-      // const EMAIL_REGEX =
-      //   /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-      // if (EMAIL_REGEX.test(loginEmail)) {
-      //   setIsEmail(true);
-      // } else {
-      //   setIsEmail(false);
-      //   setLoginWarningMsg('* 이메일 형식이 올바르지 않습니다.');
-      // }
-
       try {
         const res = await authAxios.post('/login', {
           user: {
@@ -84,10 +74,10 @@ function Login() {
         }
 
         if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
-          setIsWrong(true);
+          setIsCorrect(false);
           setLoginWarningMsg('* 이메일 또는 비밀번호가 일치하지 않습니다.');
         } else {
-          setIsWrong(false);
+          setIsCorrect(true);
         }
       } catch (error) {
         console.log(error);
@@ -108,7 +98,7 @@ function Login() {
             placeholder: '이메일을 입력해주세요',
           }}
           handleLoginState={handleLoginEmail}
-          isWrong={isWrong}
+          isCorrect={isCorrect}
           inputValue={loginEmail}
           warningMsg={loginWarningMsg}
         />
@@ -121,6 +111,7 @@ function Login() {
           }}
           handleLoginState={handleLoginPassword}
           inputValue={loginPassword}
+          isCorrect={isCorrect}
         />
         <LoginButton
           text="로그인"

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import AuthInputForm from '../../../components/AuthInputForm';
@@ -42,6 +42,7 @@ function Login() {
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
   const navigate = useNavigate();
+  const inputRef = useRef(null);
 
   const handleLoginEmail = (e) => {
     setLoginEmail(e.target.value);
@@ -60,6 +61,10 @@ function Login() {
     }
     return setButtonNotAllow(true);
   }, [loginEmail, loginPassword]);
+
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
 
   const handleLoginClick = useCallback(
     async (e) => {
@@ -81,6 +86,7 @@ function Login() {
         if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
           setIsCorrect(false);
           setLoginWarningMsg('* 이메일 또는 비밀번호가 일치하지 않습니다.');
+          inputRef.current.focus();
         } else {
           setIsCorrect(true);
         }
@@ -102,6 +108,7 @@ function Login() {
             type: 'email',
             placeholder: '이메일을 입력해주세요',
           }}
+          inputRef={inputRef}
           handleLoginState={handleLoginEmail}
           isCorrect={isCorrect}
           inputValue={loginEmail}

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -52,7 +52,11 @@ function Login() {
 
   useEffect(() => {
     if (loginEmail && loginPassword) {
-      return setButtonNotAllow(false);
+      return (
+        setButtonNotAllow(false) ||
+        setIsCorrect(true) ||
+        setLoginWarningMsg(null)
+      );
     }
     return setButtonNotAllow(true);
   }, [loginEmail, loginPassword]);

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
 import AuthInputForm from '../../../components/AuthInputForm';
 import Button from '../../../components/common/Button';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 import Title from '../../../components/Title';
+import { userEmail, userPassword } from '../../../atoms/auth';
+import authAxios from '../../../api/authAxios';
 
 const SContainer = styled.div`
   padding: 3.4rem;
@@ -34,6 +37,31 @@ const SLink = styled(Link)`
 `;
 
 function Login() {
+  const [loginEmail, setLoginEmail] = useRecoilState(userEmail);
+  const [loginPassword, setLoginPassword] = useRecoilState(userPassword);
+
+  const handleLoginEmail = (e) => {
+    setLoginEmail(e.target.value);
+  };
+  const handleLoginPassword = (e) => {
+    setLoginPassword(e.target.value);
+  };
+
+  const handleLoginClick = async (e) => {
+    e.preventDefault();
+
+    try {
+      const data = await authAxios.post('/login', {
+        user: {
+          email: loginEmail,
+          password: loginPassword,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <SContainer>
       <Title>로그인</Title>
@@ -45,6 +73,7 @@ function Login() {
             type: 'email',
             placeholder: '이메일을 입력해주세요',
           }}
+          handleLoginState={handleLoginEmail}
         />
         <AuthInputForm
           id="password"
@@ -53,8 +82,13 @@ function Login() {
             type: 'password',
             placeholder: '비밀번호를 입력해주세요',
           }}
+          handleLoginState={handleLoginPassword}
         />
-        <LoginButton text="로그인" buttonStyle={LARGE_BUTTON} />
+        <LoginButton
+          text="로그인"
+          buttonStyle={LARGE_BUTTON}
+          onClick={handleLoginClick}
+        />
       </SFormContainer>
       <SLink to="/signup">이메일로 회원가입</SLink>
     </SContainer>

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
@@ -39,6 +39,10 @@ const SLink = styled(Link)`
 function Login() {
   const [loginEmail, setLoginEmail] = useRecoilState(userEmail);
   const [loginPassword, setLoginPassword] = useRecoilState(userPassword);
+  const [isEmail, setIsEmail] = useState(false);
+  const [isWrong, setIsWrong] = useState(false);
+  const [loginWarningMsg, setLoginWarningMsg] = useState('');
+  const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
   const handleLoginEmail = (e) => {
     setLoginEmail(e.target.value);
@@ -47,20 +51,50 @@ function Login() {
     setLoginPassword(e.target.value);
   };
 
-  const handleLoginClick = async (e) => {
-    e.preventDefault();
-
-    try {
-      const data = await authAxios.post('/login', {
-        user: {
-          email: loginEmail,
-          password: loginPassword,
-        },
-      });
-    } catch (error) {
-      console.log(error);
+  useEffect(() => {
+    if (loginEmail && loginPassword) {
+      return setButtonNotAllow(false);
     }
-  };
+    return setButtonNotAllow(true);
+  }, [loginEmail, loginPassword]);
+
+  const handleLoginClick = useCallback(
+    async (e) => {
+      e.preventDefault();
+
+      // const EMAIL_REGEX =
+      //   /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+      // if (EMAIL_REGEX.test(loginEmail)) {
+      //   setIsEmail(true);
+      // } else {
+      //   setIsEmail(false);
+      //   setLoginWarningMsg('* 이메일 형식이 올바르지 않습니다.');
+      // }
+
+      try {
+        const res = await authAxios.post('/login', {
+          user: {
+            email: loginEmail,
+            password: loginPassword,
+          },
+        });
+
+        if (!res.data.message) {
+          console.log(res.data);
+        }
+
+        if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
+          setIsWrong(true);
+          setLoginWarningMsg('* 이메일 또는 비밀번호가 일치하지 않습니다.');
+        } else {
+          setIsWrong(false);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [loginEmail, loginPassword]
+  );
 
   return (
     <SContainer>
@@ -74,6 +108,9 @@ function Login() {
             placeholder: '이메일을 입력해주세요',
           }}
           handleLoginState={handleLoginEmail}
+          isWrong={isWrong}
+          inputValue={loginEmail}
+          warningMsg={loginWarningMsg}
         />
         <AuthInputForm
           id="password"
@@ -83,11 +120,13 @@ function Login() {
             placeholder: '비밀번호를 입력해주세요',
           }}
           handleLoginState={handleLoginPassword}
+          inputValue={loginPassword}
         />
         <LoginButton
           text="로그인"
           buttonStyle={LARGE_BUTTON}
           onClick={handleLoginClick}
+          disabled={buttonNotAllow}
         />
       </SFormContainer>
       <SLink to="/signup">이메일로 회원가입</SLink>

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -96,6 +96,11 @@ function SignUp() {
     return setButtonNotAllow(true);
   }, [emailValid, passwordValid, checkPwValid]);
 
+  useEffect(() => {
+    setSignUpEmailValue('');
+    setSignUpPasswordValue('');
+  }, []);
+
   const handleJoinClick = useCallback(
     async (e) => {
       e.preventDefault();

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -49,7 +49,6 @@ function SignUp() {
   const [checkPwWarningMsg, setCheckPwWarningMsg] = useState('');
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
-  const [isUser, setIsUser] = useState(false);
 
   const handleEmailValue = (e) => {
     setSignUpEmailValue(e.target.value);
@@ -109,7 +108,7 @@ function SignUp() {
         });
 
         if (res.data.message === '이미 가입된 이메일 주소 입니다.') {
-          setIsUser(true);
+          // setIsUser(true);
           setEmailValid(false);
           setEmailWarningMsg('* 이미 가입된 이메일입니다.');
         }

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -64,7 +64,7 @@ function SignUp() {
   useEffect(() => {
     const EMAIL_REGEX =
       /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-    const PW_REGEX = /^[a-zA-Z0-9]{8,}$/;
+    const PW_REGEX = /^[a-zA-Z0-9]{6,}$/;
 
     if (EMAIL_REGEX.test(signUpEmailValue)) {
       setEmailValid(true);
@@ -78,7 +78,7 @@ function SignUp() {
     } else {
       setPasswordValid(false);
       setPwWarningMsg(
-        '* 비밀번호는 영문, 숫자를 포함하여 8자 이상이어야 합니다.'
+        '* 비밀번호는 영문, 숫자를 포함하여 6자 이상이어야 합니다.'
       );
     }
 

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -30,6 +30,7 @@ const SignUpButton = styled(Button)`
 
 function SignUp() {
   const navigate = useNavigate();
+  const inputRef = useRef(null);
 
   const goToWelcomePage = () => {
     navigate('/welcome');
@@ -99,6 +100,7 @@ function SignUp() {
   useEffect(() => {
     setSignUpEmailValue('');
     setSignUpPasswordValue('');
+    inputRef.current.focus();
   }, []);
 
   const handleJoinClick = useCallback(
@@ -113,9 +115,9 @@ function SignUp() {
         });
 
         if (res.data.message === '이미 가입된 이메일 주소 입니다.') {
-          // setIsUser(true);
           setEmailValid(false);
           setEmailWarningMsg('* 이미 가입된 이메일입니다.');
+          inputRef.current.focus();
         }
 
         if (res.data.message === '사용 가능한 이메일 입니다.') {
@@ -137,6 +139,7 @@ function SignUp() {
         <AuthInputForm
           id="email"
           label="이메일"
+          inputRef={inputRef}
           inputProps={{
             type: 'email',
             placeholder: '이메일을 입력해주세요.',


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

로그인 기능 일부 구현

## 💬 기대 결과
- 이메일, 비밀번호 인풋 값 유무에 따른 버튼 활성화, 비활성화
- 로그인 버튼 눌렀을 때 로그인 api 통신 후 이메일과 비밀번호 유효성 검사 진행
- 유효성 검사에 따른 에러 메시지 출력
- 통과하면 홈 페이지로 이동
- 최초 렌더링, 에러메시지 출력 후 인풋에 포커스 되도록

## 💬 전달사항
- post 요청만 한 상태이고 받은 데이터 가공할 차례입니다.
- 회원가입 후에 페이지를 profile로 가게 했는데 수정할 예정입니다.
- 코드가 노클린..


## 💬 스크린샷
![signUp_5](https://user-images.githubusercontent.com/101461874/208355503-e6c6c2d3-276d-4178-bebc-2b79b0b95f1b.gif)
![signUp_6](https://user-images.githubusercontent.com/101461874/208355587-3dc1a30c-4acd-49ae-844d-90dc270d3cb8.gif)
![login_3](https://user-images.githubusercontent.com/101461874/208355682-ea24b9ca-4f1f-4221-8bc7-8d0b62b99295.gif)



## 💬 Issue Number
close : #52 
