### PR TITLE
게시물 상세 페이지 세부 기능 구현

### DIFF
--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -64,7 +64,7 @@ const SPostableButton = styled.button`
   color: ${({ theme }) => theme.color.LIGHT_BLUE};
 `;
 
-function CommentInput({ id, onCreateCommentData }) {
+function CommentInput({ onCreateCommentData }) {
   const [commentData, setCommentData] = useState({
     dataId: 'test',
     content: '',
@@ -134,17 +134,17 @@ function CommentInput({ id, onCreateCommentData }) {
     <SContents>
       <STitle>댓글 입력</STitle>
       <SProfileImg src={basicProfilSmallImg} alt="프로필 이미지" />
-      <SLabel htmlFor={id} />
-      <SInputForm
-        type="text"
-        id={id}
-        placeholder="댓글 입력하기..."
-        name="content"
-        value={commentData.content}
-        onChange={handleCommentData}
-        rows="1"
-        className="autoTextarea"
-      />
+      <SLabel>
+        <SInputForm
+          type="text"
+          placeholder="댓글 입력하기..."
+          name="content"
+          value={commentData.content}
+          onChange={handleCommentData}
+          rows="1"
+          className="autoTextarea"
+        />
+      </SLabel>
       {commentData.content.length === 0 ? (
         <SNotPostableButton type="button" onClick={handleCommentSubmit}>
           게시

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -75,7 +75,6 @@ function CommentInput({ id, onCreateCommentData }) {
     const textarea = document.querySelector('.autoTextarea');
 
     if (textarea) {
-      textarea.style.height = 'auto';
       const height = textarea.scrollHeight;
       if (height < 57) {
         textarea.style.height = `${height + 1}px`;
@@ -97,6 +96,8 @@ function CommentInput({ id, onCreateCommentData }) {
     if (commentData.content.length < 1) {
       alert('댓글을 입력해주세요.');
     } else {
+      const textarea = document.querySelector('.autoTextarea');
+      textarea.style.height = 'auto';
       onCreateCommentData(
         commentData.dataId,
         commentData.content,

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -29,10 +29,14 @@ const SLabel = styled.label`
   ${IR}
 `;
 
-const SInputForm = styled.input`
+const SInputForm = styled.textarea`
   width: 100%;
+  height: 1.9rem;
   margin: 0 1.8rem;
+  padding: 0;
   border-style: none;
+  font-family: 'LINESeedKR-Rg';
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   &::placeholder {
     color: ${({ theme }) => theme.color.LIGHT_GRAY};
   }
@@ -99,6 +103,7 @@ function CommentInput({ id, onCreateCommentData }) {
       <SProfileImg src={basicProfilSmallImg} alt="프로필 이미지" />
       <SLabel htmlFor={id} />
       <SInputForm
+        type="text"
         id={id}
         placeholder="댓글 입력하기..."
         name="content"

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -42,11 +42,18 @@ const SInputForm = styled.textarea`
   }
 `;
 
-const SButton = styled.button`
+const SNotPostableButton = styled.button`
   width: 2.5rem;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   white-space: nowrap;
   color: ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+const SPostableButton = styled.button`
+  width: 2.5rem;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  white-space: nowrap;
+  color: ${({ theme }) => theme.color.LIGHT_BLUE};
 `;
 
 function CommentInput({ id, onCreateCommentData }) {
@@ -110,9 +117,15 @@ function CommentInput({ id, onCreateCommentData }) {
         value={commentData.content}
         onChange={handleCommentData}
       />
-      <SButton type="button" onClick={handleCommentSubmit}>
-        게시
-      </SButton>
+      {commentData.content.length === 0 ? (
+        <SNotPostableButton type="button" onClick={handleCommentSubmit}>
+          게시
+        </SNotPostableButton>
+      ) : (
+        <SPostableButton type="button" onClick={handleCommentSubmit}>
+          게시
+        </SPostableButton>
+      )}
     </SContents>
   );
 }

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -5,7 +5,7 @@ import basicProfilSmallImg from '../../../assets/basic-profile_small.png';
 import { IR } from '../../../styles/Util';
 
 const SContents = styled.section`
-  position: sticky;
+  position: fixed;
   bottom: 0;
   display: flex;
   width: 100%;

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -9,9 +9,8 @@ const SContents = styled.section`
   bottom: 0;
   display: flex;
   width: 100%;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.25rem 1.6rem;
+  justify-content: center;
+  padding: 2.3rem 1.6rem 2rem;
   background-color: ${({ theme }) => theme.color.WHITE};
   border-top: 0.05rem solid ${({ theme }) => theme.color.LIGHT_GRAY};
 `;
@@ -21,6 +20,9 @@ const STitle = styled.h2`
 `;
 
 const SProfileImg = styled.img`
+  position: absolute;
+  left: 1.6rem;
+  bottom: 1.2rem;
   width: 3.6rem;
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
 `;
@@ -30,19 +32,22 @@ const SLabel = styled.label`
 `;
 
 const SInputForm = styled.textarea`
-  width: 100%;
-  height: 1.9rem;
+  width: 70%;
   margin: 0 1.8rem;
   padding: 0;
   border-style: none;
   font-family: 'LINESeedKR-Rg';
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+
   &::placeholder {
     color: ${({ theme }) => theme.color.LIGHT_GRAY};
   }
 `;
 
 const SNotPostableButton = styled.button`
+  position: absolute;
+  right: 1.6rem;
+  bottom: 2.1rem;
   width: 2.5rem;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   white-space: nowrap;
@@ -50,6 +55,9 @@ const SNotPostableButton = styled.button`
 `;
 
 const SPostableButton = styled.button`
+  position: absolute;
+  right: 1.6rem;
+  bottom: 2.1rem;
   width: 2.5rem;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   white-space: nowrap;
@@ -71,17 +79,35 @@ function CommentInput({ id, onCreateCommentData }) {
     },
   });
 
+  const handleResizeHeight = () => {
+    const textarea = document.querySelector('.autoTextarea');
+
+    if (textarea) {
+      textarea.style.height = 'auto';
+      const height = textarea.scrollHeight;
+      if (height < 57) {
+        textarea.style.height = `${height + 1}px`;
+      } else {
+        textarea.style.height = `57px`;
+      }
+    }
+  };
+
   const handleCommentData = (e) => {
     setCommentData({
       ...commentData,
       [e.target.name]: e.target.value,
     });
+    handleResizeHeight();
   };
 
   const handleCommentSubmit = () => {
     if (commentData.content.length < 1) {
       alert('댓글을 입력해주세요.');
     } else {
+      const textarea = document.querySelector('.autoTextarea');
+      const height = textarea.scrollHeight;
+      textarea.style.height = 'auto';
       onCreateCommentData(
         commentData.dataId,
         commentData.content,
@@ -116,6 +142,8 @@ function CommentInput({ id, onCreateCommentData }) {
         name="content"
         value={commentData.content}
         onChange={handleCommentData}
+        rows="1"
+        className="autoTextarea"
       />
       {commentData.content.length === 0 ? (
         <SNotPostableButton type="button" onClick={handleCommentSubmit}>

--- a/src/components/Comment/CommentInput/index.jsx
+++ b/src/components/Comment/CommentInput/index.jsx
@@ -44,27 +44,18 @@ const SInputForm = styled.textarea`
   }
 `;
 
-const SNotPostableButton = styled.button`
+const SButton = styled.button`
   position: absolute;
   right: 1.6rem;
   bottom: 2.1rem;
   width: 2.5rem;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   white-space: nowrap;
-  color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  color: ${({ theme, contentLength }) =>
+    contentLength === 0 ? theme.color.LIGHT_GRAY : theme.color.LIGHT_BLUE};
 `;
 
-const SPostableButton = styled.button`
-  position: absolute;
-  right: 1.6rem;
-  bottom: 2.1rem;
-  width: 2.5rem;
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  white-space: nowrap;
-  color: ${({ theme }) => theme.color.LIGHT_BLUE};
-`;
-
-function CommentInput({ onCreateCommentData }) {
+function CommentInput({ id, onCreateCommentData }) {
   const [commentData, setCommentData] = useState({
     dataId: 'test',
     content: '',
@@ -80,6 +71,7 @@ function CommentInput({ onCreateCommentData }) {
   });
 
   const handleResizeHeight = () => {
+    //  DOM 접근할 때, useRef 사용해서 바꿔보기
     const textarea = document.querySelector('.autoTextarea');
 
     if (textarea) {
@@ -105,9 +97,6 @@ function CommentInput({ onCreateCommentData }) {
     if (commentData.content.length < 1) {
       alert('댓글을 입력해주세요.');
     } else {
-      const textarea = document.querySelector('.autoTextarea');
-      const height = textarea.scrollHeight;
-      textarea.style.height = 'auto';
       onCreateCommentData(
         commentData.dataId,
         commentData.content,
@@ -134,26 +123,25 @@ function CommentInput({ onCreateCommentData }) {
     <SContents>
       <STitle>댓글 입력</STitle>
       <SProfileImg src={basicProfilSmallImg} alt="프로필 이미지" />
-      <SLabel>
-        <SInputForm
-          type="text"
-          placeholder="댓글 입력하기..."
-          name="content"
-          value={commentData.content}
-          onChange={handleCommentData}
-          rows="1"
-          className="autoTextarea"
-        />
-      </SLabel>
-      {commentData.content.length === 0 ? (
-        <SNotPostableButton type="button" onClick={handleCommentSubmit}>
-          게시
-        </SNotPostableButton>
-      ) : (
-        <SPostableButton type="button" onClick={handleCommentSubmit}>
-          게시
-        </SPostableButton>
-      )}
+      <SLabel htmlFor={id}>댓글 입력창</SLabel>
+      <SInputForm
+        type="text"
+        id={id}
+        placeholder="댓글 입력하기..."
+        name="content"
+        value={commentData.content}
+        onChange={handleCommentData}
+        rows="1"
+        className="autoTextarea"
+      />
+
+      <SButton
+        type="button"
+        onClick={handleCommentSubmit}
+        contentLength={commentData.content.length}
+      >
+        게시
+      </SButton>
     </SContents>
   );
 }

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -44,6 +44,7 @@ const SVerticalButton = styled.button`
 const SComments = styled.p`
   margin: 0.4rem 4.8rem 0;
   font-size: 1.4rem;
+  word-break: break-all;
 `;
 
 function CommentItem({ content, createdAt, author }) {

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -41,10 +41,12 @@ const SVerticalButton = styled.button`
   width: 2rem;
 `;
 
-const SComments = styled.p`
+const SComments = styled.pre`
   margin: 0.4rem 4.8rem 0;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   word-break: break-all;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 `;
 
 function CommentItem({ content, createdAt, author }) {

--- a/src/components/Comment/CommentItem/index.jsx
+++ b/src/components/Comment/CommentItem/index.jsx
@@ -18,11 +18,11 @@ const SCommentsInfo = styled.div`
 const SUserInfo = styled.div`
   width: 100%;
   margin: 0 1.2rem;
-  font-size: 1.4rem;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
 `;
 
 const SCommentTime = styled.span`
-  font-size: 1rem;
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
   vertical-align: top;
   color: ${({ theme }) => theme.color.LIGHT_GRAY};
 
@@ -43,7 +43,7 @@ const SVerticalButton = styled.button`
 
 const SComments = styled.p`
   margin: 0.4rem 4.8rem 0;
-  font-size: 1.4rem;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   word-break: break-all;
 `;
 

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -13,12 +13,16 @@ import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../../assets/icon/s-icon-more-vertical.png';
 import CommentList from '../../../components/Comment/CommentList';
 
-const STitle = styled.h2`
-  ${IR}
+const SPostDetail = styled.div`
+  padding-bottom: 5.8rem;
 `;
 
 const SContents = styled.section`
   font-size: 1.4rem;
+`;
+
+const STitle = styled.h2`
+  ${IR}
 `;
 
 const SDividingLine = styled.div`
@@ -48,7 +52,7 @@ function PostDetail() {
   };
 
   return (
-    <>
+    <SPostDetail>
       <BaseHeader
         leftIcon={arrowIcon}
         rightIcon={verticalIcon}
@@ -83,7 +87,7 @@ function PostDetail() {
       </SContents>
 
       <CommentInput onCreateCommentData={onCreateCommentData} />
-    </>
+    </SPostDetail>
   );
 }
 

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -18,7 +18,7 @@ const SPostDetail = styled.div`
 `;
 
 const SContents = styled.section`
-  font-size: 1.4rem;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
 `;
 
 const STitle = styled.h2`

--- a/src/pages/Post/PostDetail/index.jsx
+++ b/src/pages/Post/PostDetail/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import BaseHeader from '../../../components/common/BaseHeader';
@@ -32,6 +33,12 @@ const SDividingLine = styled.div`
 `;
 
 function PostDetail() {
+  const navigate = useNavigate();
+
+  const handleToHome = () => {
+    navigate('/home');
+  };
+
   const [commentData, setCommentData] = useState([]);
 
   const onCreateCommentData = (dataId, content, createdAt, author) => {
@@ -55,6 +62,7 @@ function PostDetail() {
     <SPostDetail>
       <BaseHeader
         leftIcon={arrowIcon}
+        leftClick={handleToHome}
         rightIcon={verticalIcon}
         rightClick={handleBottomSheetOpen}
         rightAlt="포스트 설정 버튼"


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가
  - 뒤로가기 아이콘을 클릭했을 때, 홈 화면으로 이동
  - 사용자의 댓글 입력 여부에 따라 '게시' 버튼의 색상 변경
- [x] 마크업 & 스타일
  - 댓글 내용이 길어졌을 때 개행
  - 댓글을 입력했을 때 내용이 길어지면 개행

## 💬 전달사항
- 댓글 작성/삭제는 api 통신 시작할 때 다시 구현할 예정 입니다...! 그때 DOM 조작 방법을 useRef로 사용해볼게요!
- 댓글에서 엔터키를 누르면 textarea에 스크롤이 생겨 긴 내용을 확인할 수 있습니다.

## 💬 스크린샷
![화면 기록 2022-12-20 14 16 08](https://user-images.githubusercontent.com/74060716/208589309-1aadddd2-0cb3-4262-b349-f4c624834d58.gif)

## 💬 Issue Number
close : #55 
