### PR TITLE
유저 검색 컴포넌트 UI 구현, 검색 API 로직 작성

### DIFF
--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { FOLLOW_BUTTON } from '../../../constants/buttonStyle';
+import Button from '../../common/Button';
+
+const SContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem 0rem;
+  padding: 0rem 1rem;
+
+  &:last-child {
+    margin-bottom: 5rem;
+  }
+`;
+
+const SUserImage = styled.img`
+  width: 5rem;
+  height: 5rem;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+const SUserInfo = styled.div`
+  width: 65%;
+  margin: 0 1.2rem;
+`;
+
+const SUserName = styled.p`
+  flex: 4 4 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.4rem;
+`;
+
+const SUserAccountName = styled.p`
+  flex: 4 4 0;
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
+const SButton = styled(Button)`
+  flex: 1 1 0;
+  white-space: nowrap;
+`;
+
+function SearchedUser({ image, username, accountname, isfollow }) {
+  return (
+    <SContent>
+      <SUserImage src={image} alt="프로필 이미지" />
+      <SUserInfo>
+        <SUserName>{username}</SUserName>
+        <SUserAccountName>{accountname}</SUserAccountName>
+      </SUserInfo>
+      {isfollow ? (
+        <SButton buttonStyle={FOLLOW_BUTTON} text="취소" />
+      ) : (
+        <SButton buttonStyle={FOLLOW_BUTTON} text="팔로우" />
+      )}
+    </SContent>
+  );
+}
+
+export default SearchedUser;

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -1,63 +1,52 @@
 import React from 'react';
 import styled from 'styled-components';
-
-import { FOLLOW_BUTTON } from '../../../constants/buttonStyle';
-import Button from '../../common/Button';
+import { slEllipsis } from '../../../styles/Util';
 
 const SContent = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 1rem 0rem;
+  margin: 1.2rem 0rem;
   padding: 0rem 1rem;
 
   &:last-child {
-    margin-bottom: 5rem;
+    margin-bottom: 6rem;
   }
 `;
 
 const SUserImage = styled.img`
+  min-width: 5rem;
   width: 5rem;
+  min-height: 5rem;
   height: 5rem;
   object-fit: cover;
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
 `;
 
 const SUserInfo = styled.div`
-  width: 65%;
+  width: 100%;
   margin: 0 1.2rem;
 `;
 
 const SUserName = styled.p`
-  flex: 4 4 0;
-  margin-bottom: 0.6rem;
   font-size: 1.4rem;
 `;
 
-const SUserAccountName = styled.p`
-  flex: 4 4 0;
+const SUserIntro = styled.p`
+  ${slEllipsis};
   font-size: 1.2rem;
   color: ${({ theme }) => theme.color.GRAY};
+  padding-right: 7rem;
 `;
 
-const SButton = styled(Button)`
-  flex: 1 1 0;
-  white-space: nowrap;
-`;
-
-function SearchedUser({ image, username, accountname, isfollow }) {
+function SearchedUser({ image, username, intro }) {
   return (
     <SContent>
       <SUserImage src={image} alt="프로필 이미지" />
       <SUserInfo>
         <SUserName>{username}</SUserName>
-        <SUserAccountName>{accountname}</SUserAccountName>
+        <SUserIntro>{intro}</SUserIntro>
       </SUserInfo>
-      {isfollow ? (
-        <SButton buttonStyle={FOLLOW_BUTTON} text="취소" />
-      ) : (
-        <SButton buttonStyle={FOLLOW_BUTTON} text="팔로우" />
-      )}
     </SContent>
   );
 }

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -1,17 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useQuery } from 'react-query';
+import axios from 'axios';
+
 import SearchHeader from '../common/SearchHeader';
+import SearchedUser from './SearchedUser';
 
 const SContainer = styled.div`
   height: calc(100 + 4.4) vh;
   background-color: ${({ theme }) => theme.color.WHITE};
 `;
 
+const userFetch = async (keyword) => {
+  const { data } = await axios.get(
+    `https://mandarin.api.weniv.co.kr/user/searchuser/?keyword=${keyword}`,
+    {
+      headers: {
+        Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+        'Content-type': 'application/json',
+      },
+    }
+  );
+  return data;
+};
+
 function UserSearch({ handleSearchActive }) {
+  const [searchData, setSearchData] = useState('');
+  const { data, isLoading, isError } = useQuery(
+    ['searchUser', searchData],
+    () => userFetch(searchData),
+    {
+      enabled: !!searchData,
+      select: (result) => result.slice(0, 10),
+    }
+  );
+
+  const handleSearchData = (e) => {
+    setSearchData(e.target.value);
+  };
+
+  console.log(data, searchData);
   return (
     <>
-      <SearchHeader leftClick={handleSearchActive} />
-      <SContainer>api 통신</SContainer>;
+      <SearchHeader
+        leftClick={handleSearchActive}
+        value={searchData}
+        onChange={handleSearchData}
+      />
+      {isLoading && <div>로딩 중 입니다.</div>}
+      {isError && <div>에러 발생!!</div>}
+      {data && <SContainer>{data.map((user) => console.log(user))}</SContainer>}
+      ;
     </>
   );
 }

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -49,8 +49,19 @@ function UserSearch({ handleSearchActive }) {
       />
       {isLoading && <div>로딩 중 입니다.</div>}
       {isError && <div>에러 발생!!</div>}
-      {data && <SContainer>{data.map((user) => console.log(user))}</SContainer>}
-      ;
+      {data && (
+        <SContainer>
+          {data.map((user) => (
+            <SearchedUser
+              key={user.id}
+              image={user.image}
+              username={user.username}
+              accountname={user.accountname}
+              intro={user.intro}
+            />
+          ))}
+        </SContainer>
+      )}
     </>
   );
 }

--- a/src/components/common/SearchHeader/index.jsx
+++ b/src/components/common/SearchHeader/index.jsx
@@ -38,13 +38,18 @@ const SearchInput = styled.input`
   }
 `;
 
-function SearchHeader({ leftClick }) {
+function SearchHeader({ leftClick, onChange, value }) {
   return (
     <SContainer>
       <SButton onClick={leftClick}>
         <img src={arrowIcon} alt="뒤로가기" />
       </SButton>
-      <SearchInput type="text" placeholder="계정 검색" />
+      <SearchInput
+        type="text"
+        placeholder="계정 검색"
+        value={value}
+        onChange={onChange}
+      />
     </SContainer>
   );
 }


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 검색 API 로직 작성
- [x] 마크업 & 스타일 : 검색 컴포넌트 UI 구현


## 💬 기대 결과
- 검색 가능

## 💬 전달사항
- username과 accountname으로 검색이 가능하지만 보이는건 username뿐입니다. 
  - accountname을 intro로 대체
  - 원래 input 검색 내용과 username이 동일하다면 하이라이팅 처리를 하려했는데 지금은 해도 될지 모르겠네요
    - 예를 들어 test를 입력했는데 username은 유저이고 accountname이 test인 사람인 경우 검색 내용도 존재하지 않고 하이라이팅도 안됐는데 검색되는 일이 발생 할듯합니다.


## 💬 스크린샷
![Dec-21-2022 09-59-38](https://user-images.githubusercontent.com/71367408/208795827-1df8ae86-99b0-4699-8136-58745bf1e047.gif)


## 💬 Issue Number
close : #71 
