### PR TITLE
이미지 등록 UI 및 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import Splash from './pages/Splash';
 import Welcome from './pages/Welcome';
 import ProfileEdit from './pages/Profile/ProfileEdit';
 import ProfileSetting from './pages/Auth/ProfileSetting';
+import Mypicks from './pages/Mypicks';
 
 function App() {
   return (
@@ -42,6 +43,8 @@ function App() {
           <Route path="follower" element={<Follower />} />
           <Route path="following" element={<Following />} />
         </Route>
+        <Route path="/mypicks" element={<Mypicks />} />
+
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import ConfirmHeader from '../../components/common/ConfirmHeader';
-import leftIcon from '../../assets/icon/icon-arrow-left.png';
 import Dialog from '../../components/Modal/Dialog';
+import leftIcon from '../../assets/icon/icon-arrow-left.png';
+import uploadIconGrey from '../../assets/upload-file_grey.png';
 
 function index() {
   const navigate = useNavigate();
@@ -23,7 +24,6 @@ function index() {
   };
 
   const SContainer = styled.main`
-    position: relative;
     height: calc(100 + 4.4) vh;
     display: flex;
     flex-direction: column;
@@ -33,9 +33,22 @@ function index() {
   `;
 
   const SImageContainer = styled.div`
+    position: relative;
     height: 100%;
     padding-bottom: 1rem;
     border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+    cursor: pointer;
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 1.2rem;
+      bottom: 2.2rem;
+      width: 4rem;
+      height: 4rem;
+      background-image: url(${uploadIconGrey});
+      background-size: cover;
+    }
   `;
   const SImageInput = styled.div`
     height: 20.4rem;
@@ -46,22 +59,24 @@ function index() {
     align-items: center;
     justify-content: center;
     border-radius: 1.5rem;
-    color: ${({ theme }) => theme.color.GRAY};
-    background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
+    background-color: #f2f2f2;
+    border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   `;
 
   const Simgtxt = styled.p`
     position: absolute;
-    top: 3rem;
+    top: -3rem;
     font-size: ${({ theme }) => theme.fontSize.SMALL};
+    color: ${({ theme }) => theme.color.GRAY};
   `;
 
   const Slabel = styled.label`
     font-size: ${({ theme }) => theme.fontSize.SMALL};
-    color: ${({ theme }) => theme.color.DARK_GRAY}; ;
+    color: ${({ theme }) => theme.color.GRAY};
   `;
 
   const Stextarea = styled.textarea`
+    display: block;
     margin-top: 10px;
     width: 32.2rem;
     height: 25px;
@@ -87,7 +102,7 @@ function index() {
       <SContainer>
         <SImageContainer>
           <Simgtxt>myPick 이미지 등록</Simgtxt>
-          <SImageInput>+</SImageInput>
+          <SImageInput />
           <input
             type="file"
             accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"
@@ -101,7 +116,7 @@ function index() {
             name=""
             id="something1"
             cols="30"
-            rows="10"
+            rows="1"
             placeholder="2~15자 이내여야 합니다."
           />
         </Slabel>

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,17 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+
 import ConfirmHeader from '../../components/common/ConfirmHeader';
 import Dialog from '../../components/Modal/Dialog';
 import leftIcon from '../../assets/icon/icon-arrow-left.png';
-import uploadIconGrey from '../../assets/upload-file_grey.png';
+import * as S from './index.style';
 
 function index() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const navigate = useNavigate();
   const goBackPage = () => {
     navigate(-1);
   };
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleDialogOpen = (e) => {
     e.stopPropagation();
@@ -23,69 +23,8 @@ function index() {
     goBackPage();
   };
 
-  const SContainer = styled.main`
-    height: calc(100 + 4.4) vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 6.2rem 3.4rem 0;
-    gap: 1.6rem;
-  `;
-
-  const SImageContainer = styled.div`
-    position: relative;
-    height: 100%;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-    cursor: pointer;
-
-    &::after {
-      content: '';
-      position: absolute;
-      right: 1.2rem;
-      bottom: 2.2rem;
-      width: 4rem;
-      height: 4rem;
-      background-image: url(${uploadIconGrey});
-      background-size: cover;
-    }
-  `;
-  const SImageInput = styled.div`
-    height: 20.4rem;
-    width: 32.2rem;
-    flex: 0 0 auto;
-    font-size: 3.6rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 1.5rem;
-    background-color: #f2f2f2;
-    border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  `;
-
-  const Simgtxt = styled.p`
-    position: absolute;
-    top: -3rem;
-    font-size: ${({ theme }) => theme.fontSize.SMALL};
-    color: ${({ theme }) => theme.color.GRAY};
-  `;
-
-  const Slabel = styled.label`
-    font-size: ${({ theme }) => theme.fontSize.SMALL};
-    color: ${({ theme }) => theme.color.GRAY};
-  `;
-
-  const Stextarea = styled.textarea`
-    display: block;
-    margin-top: 10px;
-    width: 32.2rem;
-    height: 25px;
-    font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-    border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  `;
-
   return (
-    <div>
+    <>
       <ConfirmHeader
         leftIcon={leftIcon}
         leftClick={goBackPage}
@@ -99,49 +38,49 @@ function index() {
         />
       )}
 
-      <SContainer>
-        <SImageContainer>
-          <Simgtxt>myPick 이미지 등록</Simgtxt>
-          <SImageInput />
+      <S.Container>
+        <S.ImageContainer>
+          <S.imgtxt>myPick 이미지 등록</S.imgtxt>
+          <S.ImageInput />
           <input
             type="file"
             accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"
             multiple
             style={{ display: 'none' }}
           />
-        </SImageContainer>
-        <Slabel htmlFor="something1">
+        </S.ImageContainer>
+        <S.label htmlFor="something1">
           항목1입니다
-          <Stextarea
+          <S.textarea
             name=""
             id="something1"
             cols="30"
             rows="1"
             placeholder="2~15자 이내여야 합니다."
           />
-        </Slabel>
-        <Slabel htmlFor="something2">
+        </S.label>
+        <S.label htmlFor="something2">
           항목2입니다
-          <Stextarea
+          <S.textarea
             name=""
             id="something2"
             cols="30"
-            rows="10"
+            rows="1"
             placeholder="숫자만 입력 가능합니다."
           />
-        </Slabel>
-        <Slabel htmlFor="something1">
+        </S.label>
+        <S.label htmlFor="something1">
           항목3입니다
-          <Stextarea
+          <S.textarea
             name=""
             id="something3"
             cols="30"
-            rows="10"
-            placeholder="폰트 적용 안되고있는데 나중에 적용 대상임"
+            rows="1"
+            placeholder="내용을 입력해주세요."
           />
-        </Slabel>
-      </SContainer>
-    </div>
+        </S.label>
+      </S.Container>
+    </>
   );
 }
 

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -37,12 +37,17 @@ function index() {
     setText(e.target.value);
   };
 
+  const [placeholderText, setPlaceholderText] =
+    useState('숫자만 입력 가능합니다.');
+
   const handleCheck = (e) => {
     setCheck(e.target.checked);
     if (check) {
+      setPlaceholderText('숫자만 입력 가능합니다.');
       setDisabled(false);
     } else {
       setText('');
+      setPlaceholderText('');
       setDisabled(true);
     }
   };
@@ -72,45 +77,40 @@ function index() {
             style={{ display: 'none' }}
           />
         </S.ImageContainer>
-        <S.Label htmlFor="something1">
-          제목
-          <S.Textarea
-            name=""
-            id="something1"
-            cols="30"
-            rows="1"
-            placeholder="2~15자 이내여야 합니다."
-          />
-        </S.Label>
-        <S.Label htmlFor="something2">
-          가격
-          <S.Textarea
-            value={text}
-            onChange={handleInputChange}
-            disabled={disabled}
-            name=""
-            id="something2"
-            cols="30"
-            rows="1"
-            placeholder={!disabled && '숫자만 입력 가능합니다.'}
-          />
-          <S.LabelCheckBox onClick={handleCheck} htmlFor="price">
-            <S.StyledP>가격 미정</S.StyledP>
-            <S.Checkbox type="checkbox" name="" id="price" />
-          </S.LabelCheckBox>
-        </S.Label>
-        <S.Label htmlFor="something1">
-          추천하는 이유
-          <S.Textarea
-            onChange={handleResizeHeight}
-            ref={textRef}
-            name=""
-            id="something3"
-            cols="30"
-            rows="1"
-            placeholder="내용을 입력해주세요."
-          />
-        </S.Label>
+        <S.Label htmlFor="something1">제목</S.Label>
+        <S.Textarea
+          name=""
+          id="something1"
+          cols="30"
+          rows="1"
+          placeholder="2~15자 이내여야 합니다."
+        />
+
+        <S.Label htmlFor="something2">가격</S.Label>
+        <S.Textarea
+          value={text}
+          onChange={handleInputChange}
+          disabled={disabled}
+          name=""
+          id="something2"
+          cols="30"
+          rows="1"
+          placeholder={placeholderText}
+        />
+        <S.Checkbox onClick={handleCheck} type="checkbox" name="" id="price" />
+        <S.LabelCheckBox htmlFor="price">
+          <S.StyledP>가격 미정</S.StyledP>
+        </S.LabelCheckBox>
+        <S.Label htmlFor="something1">후기</S.Label>
+        <S.Textarea
+          onChange={handleResizeHeight}
+          ref={textRef}
+          name=""
+          id="something3"
+          cols="30"
+          rows="1"
+          placeholder="후기를 남겨주세요."
+        />
       </S.Container>
     </>
   );

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function index() {
+  return <div>해윙</div>;
+}
+
+export default index;

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import ConfirmHeader from '../../components/common/ConfirmHeader';
 import leftIcon from '../../assets/icon/icon-arrow-left.png';
 import Dialog from '../../components/Modal/Dialog';
@@ -21,6 +22,53 @@ function index() {
     goBackPage();
   };
 
+  const SContainer = styled.main`
+    position: relative;
+    height: calc(100 + 4.4) vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 6.2rem 3.4rem 0;
+    gap: 1.6rem;
+  `;
+
+  const SImageContainer = styled.div`
+    height: 100%;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  `;
+  const SImageInput = styled.div`
+    height: 20.4rem;
+    width: 32.2rem;
+    flex: 0 0 auto;
+    font-size: 3.6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1.5rem;
+    color: ${({ theme }) => theme.color.GRAY};
+    background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  `;
+
+  const Simgtxt = styled.p`
+    position: absolute;
+    top: 3rem;
+    font-size: ${({ theme }) => theme.fontSize.SMALL};
+  `;
+
+  const Slabel = styled.label`
+    font-size: ${({ theme }) => theme.fontSize.SMALL};
+    color: ${({ theme }) => theme.color.DARK_GRAY}; ;
+  `;
+
+  const Stextarea = styled.textarea`
+    margin-top: 10px;
+    width: 32.2rem;
+    height: 25px;
+    font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+    border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  `;
+
   return (
     <div>
       <ConfirmHeader
@@ -35,6 +83,49 @@ function index() {
           dialogText="저장하시겠습니까?"
         />
       )}
+
+      <SContainer>
+        <SImageContainer>
+          <Simgtxt>myPick 이미지 등록</Simgtxt>
+          <SImageInput>+</SImageInput>
+          <input
+            type="file"
+            accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"
+            multiple
+            style={{ display: 'none' }}
+          />
+        </SImageContainer>
+        <Slabel htmlFor="something1">
+          항목1입니다
+          <Stextarea
+            name=""
+            id="something1"
+            cols="30"
+            rows="10"
+            placeholder="2~15자 이내여야 합니다."
+          />
+        </Slabel>
+        <Slabel htmlFor="something2">
+          항목2입니다
+          <Stextarea
+            name=""
+            id="something2"
+            cols="30"
+            rows="10"
+            placeholder="숫자만 입력 가능합니다."
+          />
+        </Slabel>
+        <Slabel htmlFor="something1">
+          항목3입니다
+          <Stextarea
+            name=""
+            id="something3"
+            cols="30"
+            rows="10"
+            placeholder="폰트 적용 안되고있는데 나중에 적용 대상임"
+          />
+        </Slabel>
+      </SContainer>
     </div>
   );
 }

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import ConfirmHeader from '../../components/common/ConfirmHeader';
+import leftIcon from '../../assets/icon/icon-arrow-left.png';
 
 function index() {
-  return <div>해윙</div>;
+  return (
+    <div>
+      <ConfirmHeader leftIcon={leftIcon} />
+    </div>
+  );
 }
 
 export default index;

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -8,6 +8,9 @@ import * as S from './index.style';
 
 function index() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [check, setCheck] = useState(false);
+  const [disabled, setDisabled] = useState(false);
+  const [text, setText] = useState('');
   const navigate = useNavigate();
   const goBackPage = () => {
     navigate(-1);
@@ -21,6 +24,20 @@ function index() {
   const handleSubmit = () => {
     console.log('myPick 등록');
     goBackPage();
+  };
+
+  const handleInputChange = (e) => {
+    setText(e.target.value);
+  };
+
+  const handleCheck = (e) => {
+    setCheck(e.target.checked);
+    if (check) {
+      setDisabled(false);
+    } else {
+      setText('');
+      setDisabled(true);
+    }
   };
 
   return (
@@ -60,8 +77,17 @@ function index() {
         </S.Label>
         <S.Label htmlFor="something2">
           가격
-          <S.Textarea name="" id="something2" cols="30" rows="1" />
-          <S.LabelCheckBox htmlFor="price">
+          <S.Textarea
+            value={text}
+            onChange={handleInputChange}
+            disabled={disabled}
+            name=""
+            id="something2"
+            cols="30"
+            rows="1"
+            placeholder={!disabled && '숫자만 입력 가능합니다.'}
+          />
+          <S.LabelCheckBox onClick={handleCheck} htmlFor="price">
             <S.StyledP>가격 미정</S.StyledP>
             <S.Checkbox type="checkbox" name="" id="price" />
           </S.LabelCheckBox>

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,11 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ConfirmHeader from '../../components/common/ConfirmHeader';
 import leftIcon from '../../assets/icon/icon-arrow-left.png';
+import Dialog from '../../components/Modal/Dialog';
 
 function index() {
+  const navigate = useNavigate();
+  const goBackPage = () => {
+    navigate(-1);
+  };
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleDialogOpen = (e) => {
+    e.stopPropagation();
+    setIsDialogOpen(!isDialogOpen);
+  };
+
+  const handleSubmit = () => {
+    console.log('myPick 등록');
+    goBackPage();
+  };
+
   return (
     <div>
-      <ConfirmHeader leftIcon={leftIcon} />
+      <ConfirmHeader
+        leftIcon={leftIcon}
+        leftClick={goBackPage}
+        rightClick={handleDialogOpen}
+      />
+      {isDialogOpen && (
+        <Dialog
+          handleClose={handleDialogOpen}
+          handleSubmit={handleSubmit}
+          dialogText="저장하시겠습니까?"
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
 import ConfirmHeader from '../../components/common/ConfirmHeader';
 import Dialog from '../../components/Modal/Dialog';
 import leftIcon from '../../assets/icon/icon-arrow-left.png';
+
 import * as S from './index.style';
 
 function index() {
@@ -15,6 +15,13 @@ function index() {
   const goBackPage = () => {
     navigate(-1);
   };
+
+  const textRef = useRef();
+
+  const handleResizeHeight = useCallback((e) => {
+    e.target.style.height = 'inherit';
+    e.target.style.height = `${e.target.scrollHeight}px`;
+  }, []);
 
   const handleDialogOpen = (e) => {
     e.stopPropagation();
@@ -95,6 +102,8 @@ function index() {
         <S.Label htmlFor="something1">
           추천하는 이유
           <S.Textarea
+            onChange={handleResizeHeight}
+            ref={textRef}
             name=""
             id="something3"
             cols="30"

--- a/src/pages/Mypicks/index.jsx
+++ b/src/pages/Mypicks/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-
+import styled from 'styled-components';
 import ConfirmHeader from '../../components/common/ConfirmHeader';
 import Dialog from '../../components/Modal/Dialog';
 import leftIcon from '../../assets/icon/icon-arrow-left.png';
@@ -40,45 +40,42 @@ function index() {
 
       <S.Container>
         <S.ImageContainer>
-          <S.imgtxt>myPick 이미지 등록</S.imgtxt>
+          <S.Imgtxt>myPick 이미지 등록</S.Imgtxt>
           <S.ImageInput />
           <input
             type="file"
             accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"
-            multiple
             style={{ display: 'none' }}
           />
         </S.ImageContainer>
-        <S.label htmlFor="something1">
-          항목1입니다
-          <S.textarea
+        <S.Label htmlFor="something1">
+          제목
+          <S.Textarea
             name=""
             id="something1"
             cols="30"
             rows="1"
             placeholder="2~15자 이내여야 합니다."
           />
-        </S.label>
-        <S.label htmlFor="something2">
-          항목2입니다
-          <S.textarea
-            name=""
-            id="something2"
-            cols="30"
-            rows="1"
-            placeholder="숫자만 입력 가능합니다."
-          />
-        </S.label>
-        <S.label htmlFor="something1">
-          항목3입니다
-          <S.textarea
+        </S.Label>
+        <S.Label htmlFor="something2">
+          가격
+          <S.Textarea name="" id="something2" cols="30" rows="1" />
+          <S.LabelCheckBox htmlFor="price">
+            <S.StyledP>가격 미정</S.StyledP>
+            <S.Checkbox type="checkbox" name="" id="price" />
+          </S.LabelCheckBox>
+        </S.Label>
+        <S.Label htmlFor="something1">
+          추천하는 이유
+          <S.Textarea
             name=""
             id="something3"
             cols="30"
             rows="1"
             placeholder="내용을 입력해주세요."
           />
-        </S.label>
+        </S.Label>
       </S.Container>
     </>
   );

--- a/src/pages/Mypicks/index.style.js
+++ b/src/pages/Mypicks/index.style.js
@@ -58,6 +58,9 @@ export const Textarea = styled.textarea`
   height: 25px;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const LabelCheckBox = styled.label`

--- a/src/pages/Mypicks/index.style.js
+++ b/src/pages/Mypicks/index.style.js
@@ -1,21 +1,30 @@
 import styled from 'styled-components';
 import uploadIconGrey from '../../assets/upload-file_grey.png';
+import { IR } from '../../styles/Util';
 
 export const Container = styled.main`
-  height: calc(100 + 4.4) vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 6.2rem 3.4rem 0;
-  gap: 1.6rem;
+  gap: 1rem;
+  height: calc(100 + 4.4) vh;
+  padding: 6.2rem 3.4rem 3rem;
 `;
+
 export const ImageContainer = styled.div`
   position: relative;
   height: 100%;
   padding-bottom: 1rem;
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   cursor: pointer;
-
+`;
+export const ImageInput = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+  width: 100%;
+  height: 20.4rem;
+  border-radius: 1.5rem;
+  background-color: #f2f2f2;
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   &::after {
     content: '';
     position: absolute;
@@ -26,18 +35,6 @@ export const ImageContainer = styled.div`
     background-image: url(${uploadIconGrey});
     background-size: cover;
   }
-`;
-export const ImageInput = styled.div`
-  height: 20.4rem;
-  width: 32.2rem;
-  flex: 0 0 auto;
-  font-size: 3.6rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 1.5rem;
-  background-color: #f2f2f2;
-  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
 `;
 export const Imgtxt = styled.p`
   position: absolute;
@@ -51,34 +48,57 @@ export const Label = styled.label`
   font-size: ${({ theme }) => theme.fontSize.SMALL};
   color: ${({ theme }) => theme.color.GRAY};
 `;
+
+// textarea, label에 fontfamily 임시 적용중
+
 export const Textarea = styled.textarea`
+  font-family: 'LINESeedKR-Rg';
   display: block;
-  margin-top: 10px;
-  width: 32.2rem;
+  margin-top: 0.3rem;
+  width: 100%;
   height: 25px;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   &::-webkit-scrollbar {
     display: none;
   }
+  &::placeholder {
+    font-family: 'LINESeedKR-Rg';
+    color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  }
 `;
 
 export const LabelCheckBox = styled.label`
+  position: relative;
   display: flex;
   align-items: center;
-  user-select: none;
   width: 30%;
-`;
+  user-select: none;
+  cursor: default;
+  font-family: 'LINESeedKR-Rg';
+  letter-spacing: -0.3px;
 
-export const Checkbox = styled.input`
-  appearance: none;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1.5px solid gainsboro;
-  border-radius: 0.35rem;
-
-  &:checked {
-    border-color: transparent;
+  &::before {
+    display: block;
+    content: '';
+    height: 1.5rem;
+    width: 1.5rem;
+    background-color: white;
+    border: 2px solid gainsboro;
+    border-radius: 0.35rem;
+  }
+  &::after {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+    display: block;
+    opacity: 0;
+    content: '';
+    height: 1.5rem;
+    width: 1.5rem;
+    border: 2px solid transparent;
+    border-radius: 0.35rem;
     background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
     background-size: 100% 100%;
     background-position: 50%;
@@ -87,6 +107,17 @@ export const Checkbox = styled.input`
   }
 `;
 
+export const Checkbox = styled.input`
+  ${IR}
+  &:checked + ${LabelCheckBox} {
+    ::after {
+      opacity: 1;
+    }
+  }
+`;
+
 export const StyledP = styled.p`
   margin-left: 0.5rem;
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
+  color: ${({ theme }) => theme.color.GRAY};
 `;

--- a/src/pages/Mypicks/index.style.js
+++ b/src/pages/Mypicks/index.style.js
@@ -39,21 +39,51 @@ export const ImageInput = styled.div`
   background-color: #f2f2f2;
   border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
 `;
-export const imgtxt = styled.p`
+export const Imgtxt = styled.p`
   position: absolute;
   top: -3rem;
   font-size: ${({ theme }) => theme.fontSize.SMALL};
   color: ${({ theme }) => theme.color.GRAY};
+  cursor: default;
 `;
-export const label = styled.label`
+
+export const Label = styled.label`
   font-size: ${({ theme }) => theme.fontSize.SMALL};
   color: ${({ theme }) => theme.color.GRAY};
 `;
-export const textarea = styled.textarea`
+export const Textarea = styled.textarea`
   display: block;
   margin-top: 10px;
   width: 32.2rem;
   height: 25px;
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};
   border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+export const LabelCheckBox = styled.label`
+  display: flex;
+  align-items: center;
+  user-select: none;
+  width: 30%;
+`;
+
+export const Checkbox = styled.input`
+  appearance: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1.5px solid gainsboro;
+  border-radius: 0.35rem;
+
+  &:checked {
+    border-color: transparent;
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+    background-size: 100% 100%;
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+  }
+`;
+
+export const StyledP = styled.p`
+  margin-left: 0.5rem;
 `;

--- a/src/pages/Mypicks/index.style.js
+++ b/src/pages/Mypicks/index.style.js
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import uploadIconGrey from '../../assets/upload-file_grey.png';
+
+export const Container = styled.main`
+  height: calc(100 + 4.4) vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6.2rem 3.4rem 0;
+  gap: 1.6rem;
+`;
+export const ImageContainer = styled.div`
+  position: relative;
+  height: 100%;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  cursor: pointer;
+
+  &::after {
+    content: '';
+    position: absolute;
+    right: 1.2rem;
+    bottom: 2.2rem;
+    width: 4rem;
+    height: 4rem;
+    background-image: url(${uploadIconGrey});
+    background-size: cover;
+  }
+`;
+export const ImageInput = styled.div`
+  height: 20.4rem;
+  width: 32.2rem;
+  flex: 0 0 auto;
+  font-size: 3.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1.5rem;
+  background-color: #f2f2f2;
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+export const imgtxt = styled.p`
+  position: absolute;
+  top: -3rem;
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+export const label = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+export const textarea = styled.textarea`
+  display: block;
+  margin-top: 10px;
+  width: 32.2rem;
+  height: 25px;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 이미지 등록 UI 부기능 구현
- 헤더 뒤로가기 및 저장 버튼 누르면 Dialog 모달 띄움 기능
- 입력란 두 번째 항목(가격) 체크박스 만들어 선택적으로 입력 가능하게 함
- 입력란 세 번째 항목(후기) textarea 높이 자동 조절 기능
- [x] 마크업 & 스타일 : 이미지 등록 UI 구현 
- [x] 리팩토링 : 마크업, CSS 간단한 리팩토링 


## 💬 기대 결과
- UI 완성, 입력란 유효성 체크와 이미지 등록 기능 제외한 부가적인 기능들 완성 

## 💬 전달사항

- 📌 적절한 컨텐츠 ?
프로필에 pinned되는 간단한 후기들이라고 생각하여 이미지, 제목, 가격(선택사항), 후기 이렇게 구성했습니다. 라벨명이나 컨텐츠는 더 좋은 것 떠오르거나 의견 나오면 적극 반영하겠습니다!! 

- 📌 textarea, label 등에 fontfamily 임시 적용중
textarea, placeholder에 폰트패밀리 적용되지 않아 정확한 스타일을 볼 수 없어서 임시 적용중, 주석으로 표시해놨음 -> 추후 정리 필요 

- 처음 목표로 UI만 하기였는데 부가적인 기능도 겸사겸사 하게 되네요 ㅎㅎ rightIcon 불러오면 rightClick 함수 만들어야지 뭐 그런 거........ 😂

## 💬 스크린샷
<img width="381" alt="스크린샷 2022-12-21 23 26 14" src="https://user-images.githubusercontent.com/95897068/208928118-63441ab1-af3e-48d5-ae68-693e713e706c.png">

기본 화면 

<img width="556" alt="스크린샷 2022-12-21 23 23 32" src="https://user-images.githubusercontent.com/95897068/208927534-db6801f3-cf02-4cae-a50c-f54353c3daa5.png">

늘어나면 이렇게 됩니다. 

https://user-images.githubusercontent.com/95897068/208928048-1e05a445-8f82-4b16-9ac0-71e406d35aac.mov

시연 영상 

## 💬 Issue Number
close : #72
