### PR TITLE
유저 검색 페이지 기능 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
     "no-useless-concat": "off",
     "react/no-unknown-property": "off",
     "react/jsx-props-no-spreading": "off",
-    "no-alert": "off"
+    "no-alert": "off",
+    "no-underscore-dangle": "off"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import Welcome from './pages/Welcome';
 import ProfileEdit from './pages/Profile/ProfileEdit';
 import ProfileSetting from './pages/Auth/ProfileSetting';
 import Mypicks from './pages/Mypicks';
+import Search from './pages/Search';
 
 function App() {
   return (
@@ -30,6 +31,7 @@ function App() {
           <Route path="profile" element={<ProfileSetting />} />
         </Route>
         <Route path="/home" element={<Home />} />
+        <Route path="/search" element={<Search />} />
         <Route path="/chat" element={<Chat />} />
         <Route path="/chat/:id" element={<ChatDetail />} />
         <Route path="/post">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ function App() {
         </Route>
         <Route path="/profile">
           <Route index element={<Profile />} />
+          <Route path=":id" element={<Profile />} />
           <Route path="edit" element={<ProfileEdit />} />
           <Route path="follower" element={<Follower />} />
           <Route path="following" element={<Following />} />

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -1,51 +1,7 @@
 import React from 'react';
-import styled from 'styled-components';
-import { slEllipsis } from '../../../styles/Util';
+
 import basicProfileImage from '../../../assets/basic-profile.png';
-
-const SContent = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 1.2rem 0rem;
-  padding: 0rem 1rem;
-`;
-
-const SUserImage = styled.img`
-  min-width: 5rem;
-  width: 5rem;
-  min-height: 5rem;
-  height: 5rem;
-  object-fit: cover;
-  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
-`;
-
-const SUserInfo = styled.div`
-  width: 100%;
-  margin: 0 1.2rem;
-`;
-
-const SUserName = styled.p`
-  display: flex;
-  font-size: 1.4rem;
-
-  strong {
-    color: ${({ theme }) => theme.color.ACTIVE_BLUE};
-  }
-
-  span {
-    font-size: 1rem;
-    margin-left: 0.5rem;
-    color: ${({ theme }) => theme.color.GRAY};
-  }
-`;
-
-const SUserIntro = styled.p`
-  ${slEllipsis};
-  font-size: 1.2rem;
-  color: ${({ theme }) => theme.color.GRAY};
-  padding-right: 7rem;
-`;
+import * as S from './index.styles';
 
 function SearchedUser({
   image,
@@ -63,19 +19,18 @@ function SearchedUser({
   };
 
   return (
-    <SContent onClick={goToProfile}>
-      <SUserImage src={image} alt="프로필 이미지" onError={handleErrorImage} />
-      <SUserInfo>
-        <SUserName>
+    <S.Content onClick={goToProfile}>
+      <S.UserImage src={image} alt="프로필 이미지" onError={handleErrorImage} />
+      <S.UserInfo>
+        <S.UserName>
           {leftText}
           <strong>{keyword}</strong>
           {rightText}
           <span>@{accountname}</span>
-        </SUserName>
-
-        <SUserIntro>{intro}</SUserIntro>
-      </SUserInfo>
-    </SContent>
+        </S.UserName>
+        <S.UserIntro>{intro}</S.UserIntro>
+      </S.UserInfo>
+    </S.Content>
   );
 }
 

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -39,9 +39,9 @@ const SUserIntro = styled.p`
   padding-right: 7rem;
 `;
 
-function SearchedUser({ image, username, intro }) {
+function SearchedUser({ image, username, intro, goToProfile }) {
   return (
-    <SContent>
+    <SContent onClick={goToProfile}>
       <SUserImage src={image} alt="프로필 이미지" />
       <SUserInfo>
         <SUserName>{username}</SUserName>

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -26,6 +26,10 @@ const SUserInfo = styled.div`
 
 const SUserName = styled.p`
   font-size: 1.4rem;
+
+  strong {
+    color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+  }
 `;
 
 const SUserIntro = styled.p`
@@ -35,12 +39,19 @@ const SUserIntro = styled.p`
   padding-right: 7rem;
 `;
 
-function SearchedUser({ image, username, intro, goToProfile }) {
+function SearchedUser({ image, username, intro, goToProfile, keyword }) {
+  const leftText = username.split(keyword)[0];
+  const rightText = username.split(keyword)[1];
+
   return (
     <SContent onClick={goToProfile}>
       <SUserImage src={image} alt="프로필 이미지" />
       <SUserInfo>
-        <SUserName>{username}</SUserName>
+        <SUserName>
+          {leftText}
+          <strong>{keyword}</strong>
+          {rightText}
+        </SUserName>
         <SUserIntro>{intro}</SUserIntro>
       </SUserInfo>
     </SContent>

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { slEllipsis } from '../../../styles/Util';
+import basicProfileImage from '../../../assets/basic-profile.png';
 
 const SContent = styled.div`
   display: flex;
@@ -43,9 +44,13 @@ function SearchedUser({ image, username, intro, goToProfile, keyword }) {
   const leftText = username.split(keyword)[0];
   const rightText = username.split(keyword)[1];
 
+  const handleErrorImage = (e) => {
+    e.target.src = basicProfileImage;
+  };
+
   return (
     <SContent onClick={goToProfile}>
-      <SUserImage src={image} alt="프로필 이미지" />
+      <SUserImage src={image} alt="프로필 이미지" onError={handleErrorImage} />
       <SUserInfo>
         <SUserName>
           {leftText}

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -26,10 +26,17 @@ const SUserInfo = styled.div`
 `;
 
 const SUserName = styled.p`
+  display: flex;
   font-size: 1.4rem;
 
   strong {
     color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+  }
+
+  span {
+    font-size: 1rem;
+    margin-left: 0.5rem;
+    color: ${({ theme }) => theme.color.GRAY};
   }
 `;
 
@@ -40,7 +47,14 @@ const SUserIntro = styled.p`
   padding-right: 7rem;
 `;
 
-function SearchedUser({ image, username, intro, goToProfile, keyword }) {
+function SearchedUser({
+  image,
+  username,
+  intro,
+  goToProfile,
+  accountname,
+  keyword,
+}) {
   const leftText = username.split(keyword)[0];
   const rightText = username.split(keyword)[1];
 
@@ -56,7 +70,9 @@ function SearchedUser({ image, username, intro, goToProfile, keyword }) {
           {leftText}
           <strong>{keyword}</strong>
           {rightText}
+          <span>@{accountname}</span>
         </SUserName>
+
         <SUserIntro>{intro}</SUserIntro>
       </SUserInfo>
     </SContent>

--- a/src/components/UserSearch/SearchedUser/index.jsx
+++ b/src/components/UserSearch/SearchedUser/index.jsx
@@ -8,10 +8,6 @@ const SContent = styled.div`
   align-items: center;
   margin: 1.2rem 0rem;
   padding: 0rem 1rem;
-
-  &:last-child {
-    margin-bottom: 6rem;
-  }
 `;
 
 const SUserImage = styled.img`

--- a/src/components/UserSearch/SearchedUser/index.styles.js
+++ b/src/components/UserSearch/SearchedUser/index.styles.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { slEllipsis } from '../../../styles/Util';
+
+export const Content = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1.2rem 0rem;
+  padding: 0rem 1rem;
+`;
+
+export const UserImage = styled.img`
+  min-width: 5rem;
+  width: 5rem;
+  min-height: 5rem;
+  height: 5rem;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+export const UserInfo = styled.div`
+  width: 100%;
+  margin: 0 1.2rem;
+`;
+
+export const UserName = styled.p`
+  display: flex;
+  font-size: 1.4rem;
+
+  strong {
+    color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+  }
+
+  span {
+    font-size: 1rem;
+    margin-left: 0.5rem;
+    color: ${({ theme }) => theme.color.GRAY};
+  }
+`;
+
+export const UserIntro = styled.p`
+  ${slEllipsis};
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.color.GRAY};
+  padding-right: 7rem;
+`;

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -12,6 +12,14 @@ const SContainer = styled.div`
   background-color: ${({ theme }) => theme.color.WHITE};
 `;
 
+const SMoreView = styled.p`
+  text-align: center;
+  margin-bottom: 8rem;
+
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+`;
+
 const userFetch = async (keyword) => {
   const { data } = await axios.get(
     `https://mandarin.api.weniv.co.kr/user/searchuser/?keyword=${keyword}`,
@@ -27,6 +35,7 @@ const userFetch = async (keyword) => {
 
 function UserSearch({ handleSearchActive }) {
   const [searchData, setSearchData] = useState('');
+  const [viewCount, setViewCount] = useState(1);
   const navigate = useNavigate();
 
   const { data, isLoading, isError } = useQuery(
@@ -34,12 +43,16 @@ function UserSearch({ handleSearchActive }) {
     () => userFetch(searchData),
     {
       enabled: !!searchData,
-      select: (result) => result.slice(0, 10),
+      select: (result) => result.slice(0, viewCount * 10),
     }
   );
 
   const handleSearchData = (e) => {
     setSearchData(e.target.value);
+  };
+
+  const handleMoreView = () => {
+    setViewCount(viewCount + 1);
   };
 
   const goToProfile = (accountname) => {
@@ -67,6 +80,7 @@ function UserSearch({ handleSearchActive }) {
               goToProfile={() => goToProfile(user.accountname)}
             />
           ))}
+          <SMoreView onClick={handleMoreView}>더 보기</SMoreView>
         </SContainer>
       )}
     </>

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -20,6 +20,13 @@ const SMoreView = styled.p`
   color: ${({ theme }) => theme.color.ACTIVE_BLUE};
 `;
 
+const SMessage = styled.p`
+  text-align: center;
+  margin-top: 1rem;
+
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+`;
+
 const userFetch = async (keyword) => {
   const { data } = await axios.get(
     `https://mandarin.api.weniv.co.kr/user/searchuser/?keyword=${keyword}`,
@@ -43,12 +50,13 @@ function UserSearch({ handleSearchActive }) {
     () => userFetch(keyword),
     {
       enabled: !!keyword,
-      select: (result) => result.slice(0, viewCount * 10),
+      select: (result) => result.slice(0, viewCount * 5),
     }
   );
 
   const handleSearchData = (e) => {
     setKeyword(e.target.value);
+    setViewCount(1);
   };
 
   const handleMoreView = () => {
@@ -68,21 +76,24 @@ function UserSearch({ handleSearchActive }) {
       />
       {isLoading && <div>로딩 중 입니다.</div>}
       {isError && <div>에러 발생!!</div>}
-      {data && (
-        <SContainer>
-          {data.map((user) => (
-            <SearchedUser
-              key={user._id}
-              image={user.image}
-              username={user.username}
-              intro={user.intro}
-              keyword={keyword}
-              goToProfile={() => goToProfile(user.accountname)}
-            />
-          ))}
+      <SContainer>
+        {data?.map((user) => (
+          <SearchedUser
+            key={user._id}
+            image={user.image}
+            username={user.username}
+            intro={user.intro}
+            keyword={keyword}
+            goToProfile={() => goToProfile(user.accountname)}
+          />
+        ))}
+        {data?.length > 0 && (
           <SMoreView onClick={handleMoreView}>더 보기</SMoreView>
-        </SContainer>
-      )}
+        )}
+        {keyword && data?.length === 0 && (
+          <SMessage>검색된 이용자가 없습니다.</SMessage>
+        )}
+      </SContainer>
     </>
   );
 }

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -60,7 +60,7 @@ function UserSearch({ handleSearchActive }) {
         <SContainer>
           {data.map((user) => (
             <SearchedUser
-              key={user.id}
+              key={user._id}
               image={user.image}
               username={user.username}
               intro={user.intro}

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -40,7 +40,7 @@ const userFetch = async (keyword) => {
   return data;
 };
 
-function UserSearch({ handleSearchActive }) {
+function UserSearch() {
   const [keyword, setKeyword] = useState('');
   const [viewCount, setViewCount] = useState(1);
   const navigate = useNavigate();
@@ -67,10 +67,14 @@ function UserSearch({ handleSearchActive }) {
     navigate(`/profile/${accountname}`);
   };
 
+  const goBackPage = () => {
+    navigate(-1);
+  };
+
   return (
     <>
       <SearchHeader
-        leftClick={handleSearchActive}
+        leftClick={goBackPage}
         value={keyword}
         onChange={handleSearchData}
       />

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -1,31 +1,11 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 import SearchHeader from '../common/SearchHeader';
 import SearchedUser from './SearchedUser';
-
-const SContainer = styled.div`
-  height: calc(100 + 4.4) vh;
-  background-color: ${({ theme }) => theme.color.WHITE};
-`;
-
-const SMoreView = styled.p`
-  text-align: center;
-  margin-bottom: 8rem;
-
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  color: ${({ theme }) => theme.color.ACTIVE_BLUE};
-`;
-
-const SMessage = styled.p`
-  text-align: center;
-  margin-top: 1rem;
-
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-`;
+import * as S from './index.styles';
 
 const userFetch = async (keyword) => {
   const { data } = await axios.get(
@@ -80,7 +60,7 @@ function UserSearch() {
       />
       {isLoading && <div>로딩 중 입니다.</div>}
       {isError && <div>에러 발생!!</div>}
-      <SContainer>
+      <S.Container>
         {data?.map((user) => (
           <SearchedUser
             key={user._id}
@@ -93,12 +73,12 @@ function UserSearch() {
           />
         ))}
         {data?.length > 0 && (
-          <SMoreView onClick={handleMoreView}>더 보기</SMoreView>
+          <S.MoreView onClick={handleMoreView}>더 보기</S.MoreView>
         )}
         {keyword && data?.length === 0 && (
-          <SMessage>검색된 이용자가 없습니다.</SMessage>
+          <S.Message>검색된 이용자가 없습니다.</S.Message>
         )}
-      </SContainer>
+      </S.Container>
     </>
   );
 }

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 import SearchHeader from '../common/SearchHeader';
@@ -26,6 +27,8 @@ const userFetch = async (keyword) => {
 
 function UserSearch({ handleSearchActive }) {
   const [searchData, setSearchData] = useState('');
+  const navigate = useNavigate();
+
   const { data, isLoading, isError } = useQuery(
     ['searchUser', searchData],
     () => userFetch(searchData),
@@ -37,6 +40,10 @@ function UserSearch({ handleSearchActive }) {
 
   const handleSearchData = (e) => {
     setSearchData(e.target.value);
+  };
+
+  const goToProfile = (accountname) => {
+    navigate(`/profile/${accountname}`);
   };
 
   console.log(data, searchData);
@@ -56,8 +63,8 @@ function UserSearch({ handleSearchActive }) {
               key={user.id}
               image={user.image}
               username={user.username}
-              accountname={user.accountname}
               intro={user.intro}
+              goToProfile={() => goToProfile(user.accountname)}
             />
           ))}
         </SContainer>

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -83,6 +83,7 @@ function UserSearch({ handleSearchActive }) {
             image={user.image}
             username={user.username}
             intro={user.intro}
+            accountname={user.accountname}
             keyword={keyword}
             goToProfile={() => goToProfile(user.accountname)}
           />

--- a/src/components/UserSearch/index.jsx
+++ b/src/components/UserSearch/index.jsx
@@ -34,21 +34,21 @@ const userFetch = async (keyword) => {
 };
 
 function UserSearch({ handleSearchActive }) {
-  const [searchData, setSearchData] = useState('');
+  const [keyword, setKeyword] = useState('');
   const [viewCount, setViewCount] = useState(1);
   const navigate = useNavigate();
 
   const { data, isLoading, isError } = useQuery(
-    ['searchUser', searchData],
-    () => userFetch(searchData),
+    ['searchUser', keyword],
+    () => userFetch(keyword),
     {
-      enabled: !!searchData,
+      enabled: !!keyword,
       select: (result) => result.slice(0, viewCount * 10),
     }
   );
 
   const handleSearchData = (e) => {
-    setSearchData(e.target.value);
+    setKeyword(e.target.value);
   };
 
   const handleMoreView = () => {
@@ -59,12 +59,11 @@ function UserSearch({ handleSearchActive }) {
     navigate(`/profile/${accountname}`);
   };
 
-  console.log(data, searchData);
   return (
     <>
       <SearchHeader
         leftClick={handleSearchActive}
-        value={searchData}
+        value={keyword}
         onChange={handleSearchData}
       />
       {isLoading && <div>로딩 중 입니다.</div>}
@@ -77,6 +76,7 @@ function UserSearch({ handleSearchActive }) {
               image={user.image}
               username={user.username}
               intro={user.intro}
+              keyword={keyword}
               goToProfile={() => goToProfile(user.accountname)}
             />
           ))}

--- a/src/components/UserSearch/index.styles.js
+++ b/src/components/UserSearch/index.styles.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  height: calc(100 + 4.4) vh;
+  background-color: ${({ theme }) => theme.color.WHITE};
+`;
+
+export const MoreView = styled.p`
+  text-align: center;
+  margin-bottom: 8rem;
+
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.ACTIVE_BLUE};
+`;
+
+export const Message = styled.p`
+  text-align: center;
+  margin-top: 1rem;
+
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+`;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'react-query';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
 import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
-
 import searchIcon from '../../assets/icon/icon-search.png';
 import logoGrey from '../../assets/logo_grey.png';
 import Button from '../../components/common/Button';
@@ -47,6 +48,7 @@ const SEmptyContent = styled.p`
 
 function Home() {
   const [isSearch, setIsSearch] = useState(false);
+  const navigate = useNavigate();
 
   const fetchPost = async () => {
     const { data } = await axios.get(
@@ -63,18 +65,18 @@ function Home() {
 
   const { data, isLoading, isError } = useQuery('postList', fetchPost);
 
-  const handleSearchActive = () => {
-    setIsSearch(!isSearch);
+  const goToSearch = () => {
+    navigate('/search');
   };
 
   return (
     <>
-      {!isSearch && !isLoading ? (
+      {!isLoading && (
         <>
           <BaseHeader
             image={hookieImage}
             rightIcon={searchIcon}
-            rightClick={handleSearchActive}
+            rightClick={goToSearch}
             rightAlt="검색창 이동"
           />
 
@@ -88,14 +90,12 @@ function Home() {
                 <Button
                   text="검색하기"
                   buttonStyle={LARGE_BUTTON}
-                  onClick={handleSearchActive}
+                  onClick={goToSearch}
                 />
               </SEmptyContainer>
             )}
           </SContainer>
         </>
-      ) : (
-        <UserSearch handleSearchActive={handleSearchActive} />
       )}
 
       <Navigation />

--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import UserSearch from '../../components/UserSearch';
+
+function Search() {
+  return <UserSearch />;
+}
+
+export default Search;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 더보기 기능, 페이지 이동 기능, 하이라이팅 기능, 액박 프로필 대체 기능 추가
- [x] 마크업 & 스타일 : 검색 결과 username, accountname, intro 모두 출력되도록 마크업, styled-components 분리


## 💬 기대 결과
- 검색 유저를 상위 5명만 보여주고 더보기 클릭 시 더 검색하는 기능 구현
- 검색된 유저 클릭 시 해당 유저의 프로필 페이지로 이동
- 검색한 내용과 동일한 username 하이라이팅
- 액박 프로필 이미지를 기본 이미지로 변경

## 💬 전달사항
- accountname까지 하이라이팅하니 이상해서 username만 하이라이팅되도록 했습니다. 


## 💬 스크린샷
![Dec-22-2022 10-37-32](https://user-images.githubusercontent.com/71367408/209035817-bf082567-730c-43d8-ad6c-2b848cb1f646.gif)



## 💬 Issue Number
close : #74 
