### PR TITLE
프로필 페이지 설정 기능 구현

### DIFF
--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -2,14 +2,14 @@ import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-function checkValid(signUpValid, inputValue, isCorrect) {
+function checkValid(signUpValid, profileValid, inputValue, isCorrect) {
   if (inputValue?.length === 0) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
     `;
   }
 
-  if (!signUpValid && inputValue?.length > 0 && !isCorrect) {
+  if (!signUpValid && !profileValid && inputValue?.length > 0 && !isCorrect) {
     return css`
       border: 1px solid ${({ theme }) => theme.color.RED};
     `;
@@ -40,8 +40,8 @@ const Input = styled.input`
     color: ${({ theme }) => theme.color.LIGHT_GRAY};
   }
 
-  ${({ signUpValid, inputValue, isCorrect }) =>
-    checkValid(signUpValid, inputValue, isCorrect)}
+  ${({ signUpValid, profileValid, inputValue, isCorrect }) =>
+    checkValid(signUpValid, profileValid, inputValue, isCorrect)}
 `;
 
 const WarningMessage = styled.p`
@@ -57,7 +57,9 @@ function AuthInputForm({
   warningMsg,
   handleSignUpState,
   handleLoginState,
+  handleProfileState,
   signUpValid,
+  profileValid,
   inputValue,
   isCorrect,
   inputRef,
@@ -71,6 +73,9 @@ function AuthInputForm({
     if (location.pathname === '/login') {
       handleLoginState(e);
     }
+    if (location.pathname === '/signup/profile') {
+      handleProfileState(e);
+    }
   };
 
   return (
@@ -82,11 +87,12 @@ function AuthInputForm({
         ref={inputRef}
         inputValue={inputValue}
         signUpValid={signUpValid}
+        profileValid={profileValid}
         isCorrect={isCorrect}
         onChange={setState}
         onKeyDown={setState}
       />
-      {!signUpValid && inputValue?.length > 0 && (
+      {!signUpValid && !profileValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>
       )}
       {isCorrect && <WarningMessage>{warningMsg}</WarningMessage>}

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
 
@@ -6,11 +6,22 @@ function ProfileImageInput() {
   const [profileImage, setProfileImage] = useState(basicProfileImage);
   const imageInput = useRef(null);
 
-  const handleImageChange = (e) => {
-    if (e.target.files[0]) {
-      setProfileImage(e.target.files[0]);
+  const handleImageChange = useCallback((e) => {
+    const currentImage = e.target.files[0];
+
+    if (currentImage) {
+      setProfileImage(currentImage);
+      // 이미지 소스 로컬스토리지에 저장
+      localStorage.setItem(
+        'image',
+        `https://mandarin.api.weniv.co.kr/${currentImage.name}`
+      );
     } else {
       setProfileImage(basicProfileImage); // 이미지 업로드 취소할 경우 기본 프로필 이미지로 설정
+      localStorage.setItem(
+        'image',
+        `https://mandarin.api.weniv.co.kr${basicProfileImage}`
+      );
     }
 
     // 업로드 이미지 preview
@@ -20,8 +31,8 @@ function ProfileImageInput() {
         setProfileImage(reader.result);
       }
     };
-    reader.readAsDataURL(e.target.files[0]);
-  };
+    reader.readAsDataURL(currentImage);
+  }, []);
 
   return (
     <S.Container

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,36 +1,51 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+
 import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
 
-function ProfileImageInput() {
+function ProfileImageInput({ handleProfileImage }) {
   const [profileImage, setProfileImage] = useState(basicProfileImage);
   const imageInput = useRef(null);
+
+  const fetchImage = async (image) => {
+    const formData = new FormData();
+
+    formData.append('image', image);
+
+    try {
+      const res = await axios.post(
+        `https://mandarin.api.weniv.co.kr/image/uploadfile`,
+        formData
+      );
+
+      handleProfileImage(res.data.filename);
+
+      return res.data.filename;
+    } catch (error) {
+      return error;
+    }
+  };
 
   const handleImageChange = useCallback((e) => {
     const currentImage = e.target.files[0];
 
     if (currentImage) {
-      setProfileImage(currentImage);
-      // 이미지 소스 로컬스토리지에 저장
-      localStorage.setItem(
-        'image',
-        `https://mandarin.api.weniv.co.kr/${currentImage.name}`
-      );
+      fetchImage(currentImage);
     } else {
-      setProfileImage(basicProfileImage); // 이미지 업로드 취소할 경우 기본 프로필 이미지로 설정
-      localStorage.setItem(
-        'image',
-        `https://mandarin.api.weniv.co.kr${basicProfileImage}`
-      );
+      setProfileImage(basicProfileImage);
+      fetchImage(basicProfileImage);
     }
 
     // 업로드 이미지 preview
     const reader = new FileReader();
+
     reader.onload = () => {
       if (reader.readyState === 2) {
         setProfileImage(reader.result);
       }
     };
+
     reader.readAsDataURL(currentImage);
   }, []);
 

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,13 +1,42 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import * as S from './index.style';
-import profileImage from '../../assets/basic-profile.png';
+import basicProfileImage from '../../assets/basic-profile.png';
 
 function ProfileImageInput() {
+  const [profileImage, setProfileImage] = useState(basicProfileImage);
+  const imageInput = useRef(null);
+
+  const handleImageChange = (e) => {
+    if (e.target.files[0]) {
+      setProfileImage(e.target.files[0]);
+    } else {
+      setProfileImage(basicProfileImage); // 이미지 업로드 취소할 경우 기본 프로필 이미지로 설정
+    }
+
+    // 업로드 이미지 preview
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.readyState === 2) {
+        setProfileImage(reader.result);
+      }
+    };
+    reader.readAsDataURL(e.target.files[0]);
+  };
+
   return (
-    <S.Container>
-      <S.ImageInput>
-        <img src={profileImage} alt="프로필 이미지" />
-      </S.ImageInput>
+    <S.Container
+      onClick={() => {
+        imageInput.current.click();
+      }}
+    >
+      <S.ImageInput src={profileImage} />
+      <input
+        type="file"
+        accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"
+        ref={imageInput}
+        style={{ display: 'none' }}
+        onChange={handleImageChange}
+      />
     </S.Container>
   );
 }

--- a/src/components/ProfileImageInput/index.style.js
+++ b/src/components/ProfileImageInput/index.style.js
@@ -24,5 +24,6 @@ export const ImageInput = styled.img`
   height: 12rem;
   margin: 0 auto;
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+  object-fit: cover;
   cursor: pointer;
 `;

--- a/src/components/ProfileImageInput/index.style.js
+++ b/src/components/ProfileImageInput/index.style.js
@@ -8,12 +8,13 @@ export const Container = styled.div`
   &::after {
     content: '';
     position: absolute;
-    bottom: 2rem;
-    right: 7rem;
+    right: 0;
+    bottom: 0;
     width: 4rem;
     height: 4rem;
     background-image: url(${uploadIcon});
     background-size: cover;
+    cursor: pointer;
   }
 `;
 
@@ -23,4 +24,5 @@ export const ImageInput = styled.img`
   height: 12rem;
   margin: 0 auto;
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+  cursor: pointer;
 `;

--- a/src/components/ProfileImageInput/index.style.js
+++ b/src/components/ProfileImageInput/index.style.js
@@ -2,25 +2,25 @@ import styled from 'styled-components';
 import uploadIcon from '../../assets/upload-file.png';
 
 export const Container = styled.div`
-  margin: 2rem 0 3rem;
-  width: 100%;
-`;
-
-export const ImageInput = styled.div`
   position: relative;
-  width: 12rem;
-  height: 12rem;
-  margin: 0 auto;
-  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+  margin: 2rem 0 3rem;
 
   &::after {
     content: '';
     position: absolute;
-    right: 0;
-    bottom: 0;
+    bottom: 2rem;
+    right: 7rem;
     width: 4rem;
     height: 4rem;
     background-image: url(${uploadIcon});
     background-size: cover;
   }
+`;
+
+export const ImageInput = styled.img`
+  display: block;
+  width: 12rem;
+  height: 12rem;
+  margin: 0 auto;
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
 `;

--- a/src/pages/Auth/Login/index.jsx
+++ b/src/pages/Auth/Login/index.jsx
@@ -81,11 +81,11 @@ function Login() {
         if (!res.data.message) {
           const userData = res.data.user;
           console.log(userData);
-          const { token, accountname, image: profileImg } = userData;
+          const { token, accountname, image } = userData;
 
           localStorage.setItem('token', JSON.stringify(token));
-          localStorage.setItem('profileImg', JSON.stringify(profileImg));
           localStorage.setItem('accountName', JSON.stringify(accountname));
+          localStorage.setItem('imageSrc', JSON.stringify(image));
 
           navigate('/home');
         }

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -14,10 +14,14 @@ function ProfileSetting() {
   const [userID, setUserID] = useState('');
   const [userName, setUserName] = useState('');
   const [intro, setIntro] = useState('');
+
   const [userIdValid, setUserIdValid] = useState(false);
   const [userNameValid, setUserNameValid] = useState(false);
+
   const [idWarningMsg, setIdWarningMsg] = useState('');
   const [nameWarningMsg, setNameWarningMsg] = useState('');
+
+  const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
   // 인풋창 입력할 때마다 유효성 검사
   useEffect(() => {
@@ -36,6 +40,14 @@ function ProfileSetting() {
     } else {
       setUserNameValid(true);
     }
+  }, [userID, userName]);
+
+  // 아이디와 이름 유효성 통과 시 버튼 활성화
+  useEffect(() => {
+    if (userIdValid && userNameValid) {
+      return setButtonNotAllow(false);
+    }
+    return setButtonNotAllow(true);
   }, [userID, userName]);
 
   // 소개 textarea 높이
@@ -105,7 +117,11 @@ function ProfileSetting() {
             onChange={handleIntro}
           />
         </S.IntroFormContainer>
-        <S.JoinButton text="후키 시작하기" buttonStyle={LARGE_BUTTON} />
+        <S.JoinButton
+          text="후키 시작하기"
+          buttonStyle={LARGE_BUTTON}
+          disabled={buttonNotAllow}
+        />
       </S.FormContainer>
     </S.Container>
   );

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -13,20 +13,20 @@ function ProfileSetting() {
   const textareaRef = useRef(null);
   const inputRef = useRef(null);
 
-  const [userID, setUserID] = useState('');
+  const [accountName, setAccountName] = useState('');
   const [userName, setUserName] = useState('');
   const [intro, setIntro] = useState('');
 
-  const [userIdValid, setUserIdValid] = useState(false);
+  const [accountNameValid, setAccountNameValid] = useState(false);
   const [userNameValid, setUserNameValid] = useState(false);
 
-  const [idWarningMsg, setIdWarningMsg] = useState('');
-  const [nameWarningMsg, setNameWarningMsg] = useState('');
+  const [accountNameWarningMsg, setAccountNameWarningMsg] = useState('');
+  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
-  const handleUserID = (e) => {
-    setUserID(e.target.value);
+  const handleAccountName = (e) => {
+    setAccountName(e.target.value);
   };
   const handleUserName = (e) => {
     setUserName(e.target.value);
@@ -37,30 +37,32 @@ function ProfileSetting() {
 
   // 인풋창 입력할 때마다 유효성 검사
   useEffect(() => {
-    const ID_REGEX = /^[a-z0-9A-Z_.]{1,}$/;
+    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
 
-    if (ID_REGEX.test(userID)) {
-      setUserIdValid(true);
+    if (ID_REGEX.test(accountName)) {
+      setAccountNameValid(true);
     } else {
-      setUserIdValid(false);
-      setIdWarningMsg('* 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.');
+      setAccountNameValid(false);
+      setAccountNameWarningMsg(
+        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
+      );
     }
 
     if (userName.length < 2 || userName.length > 10) {
       setUserNameValid(false);
-      setNameWarningMsg('* 2~10자 이내로 입력해주세요');
+      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
     } else {
       setUserNameValid(true);
     }
-  }, [userID, userName]);
+  }, [accountName, userName]);
 
   // 아이디와 이름 유효성 통과 시 버튼 활성화
   useEffect(() => {
-    if (userIdValid && userNameValid) {
+    if (accountNameValid && userNameValid) {
       return setButtonNotAllow(false);
     }
     return setButtonNotAllow(true);
-  }, [userID, userName]);
+  }, [accountName, userName]);
 
   // 아이디 인풋창 자동 포커스
   useEffect(() => {
@@ -85,13 +87,13 @@ function ProfileSetting() {
       try {
         const res = await authAxios.post('/accountnamevalid', {
           user: {
-            accountname: userID,
+            accountname: accountName,
           },
         });
 
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
-          setUserIdValid(false);
-          setIdWarningMsg('* 이미 가입된 계정ID 입니다.');
+          setAccountNameValid(false);
+          setAccountNameWarningMsg('* 이미 가입된 계정ID 입니다.');
         }
       } catch (error) {
         console.log(error);
@@ -113,10 +115,10 @@ function ProfileSetting() {
             type: 'text',
             placeholder: '아이디를 입력해주세요',
           }}
-          handleProfileState={handleUserID}
-          inputValue={userID}
-          profileValid={userIdValid}
-          warningMsg={idWarningMsg}
+          handleProfileState={handleAccountName}
+          inputValue={accountName}
+          profileValid={accountNameValid}
+          warningMsg={accountNameWarningMsg}
           inputRef={inputRef}
         />
         <AuthInputForm
@@ -129,7 +131,7 @@ function ProfileSetting() {
           handleProfileState={handleUserName}
           inputValue={userName}
           profileValid={userNameValid}
-          warningMsg={nameWarningMsg}
+          warningMsg={userNameWarningMsg}
         />
         <S.IntroFormContainer>
           <S.Label htmlFor="intro">소개</S.Label>

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './index.style';
 import Title from '../../../components/Title';
 import ProfileImageInput from '../../../components/ProfileImageInput';
 import AuthInputForm from '../../../components/AuthInputForm';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
+import authAxios from '../../../api/authAxios';
 
 function ProfileSetting() {
   const { state } = useLocation();
@@ -23,6 +24,16 @@ function ProfileSetting() {
   const [nameWarningMsg, setNameWarningMsg] = useState('');
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
+
+  const handleUserID = (e) => {
+    setUserID(e.target.value);
+  };
+  const handleUserName = (e) => {
+    setUserName(e.target.value);
+  };
+  const handleIntro = (e) => {
+    setIntro(e.target.value);
+  };
 
   // 인풋창 입력할 때마다 유효성 검사
   useEffect(() => {
@@ -51,6 +62,7 @@ function ProfileSetting() {
     return setButtonNotAllow(true);
   }, [userID, userName]);
 
+  // 아이디 인풋창 자동 포커스
   useEffect(() => {
     inputRef.current.focus();
   }, []);
@@ -66,15 +78,27 @@ function ProfileSetting() {
     if (!state?.email || !state?.password) navigate('/signup');
   }, []);
 
-  const handleUserID = (e) => {
-    setUserID(e.target.value);
-  };
-  const handleUserName = (e) => {
-    setUserName(e.target.value);
-  };
-  const handleIntro = (e) => {
-    setIntro(e.target.value);
-  };
+  const handleStartClick = useCallback(
+    async (e) => {
+      e.preventDefault();
+
+      try {
+        const res = await authAxios.post('/accountnamevalid', {
+          user: {
+            accountname: userID,
+          },
+        });
+
+        if (res.data.message === '이미 가입된 계정ID 입니다.') {
+          setUserIdValid(false);
+          setIdWarningMsg('* 이미 가입된 계정ID 입니다.');
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [buttonNotAllow]
+  );
 
   return (
     <S.Container>
@@ -127,6 +151,7 @@ function ProfileSetting() {
           text="후키 시작하기"
           buttonStyle={LARGE_BUTTON}
           disabled={buttonNotAllow}
+          onClick={handleStartClick}
         />
       </S.FormContainer>
     </S.Container>

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -10,6 +10,7 @@ function ProfileSetting() {
   const { state } = useLocation();
   const navigate = useNavigate();
   const textareaRef = useRef(null);
+  const inputRef = useRef(null);
 
   const [userID, setUserID] = useState('');
   const [userName, setUserName] = useState('');
@@ -50,6 +51,10 @@ function ProfileSetting() {
     return setButtonNotAllow(true);
   }, [userID, userName]);
 
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
+
   // 소개 textarea 높이
   const handleResizeHeight = () => {
     textareaRef.current.style.height = `38px`;
@@ -88,6 +93,7 @@ function ProfileSetting() {
           inputValue={userID}
           profileValid={userIdValid}
           warningMsg={idWarningMsg}
+          inputRef={inputRef}
         />
         <AuthInputForm
           id="name"

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -9,9 +9,36 @@ import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 function ProfileSetting() {
   const { state } = useLocation();
   const navigate = useNavigate();
+  const textareaRef = useRef(null);
+
+  const [userID, setUserID] = useState('');
+  const [userName, setUserName] = useState('');
+  const [intro, setIntro] = useState('');
+  const [userIdValid, setUserIdValid] = useState(false);
+  const [userNameValid, setUserNameValid] = useState(false);
+  const [idWarningMsg, setIdWarningMsg] = useState('');
+  const [nameWarningMsg, setNameWarningMsg] = useState('');
+
+  // 인풋창 입력할 때마다 유효성 검사
+  useEffect(() => {
+    const ID_REGEX = /^[a-z0-9A-Z_.]{1,}$/;
+
+    if (ID_REGEX.test(userID)) {
+      setUserIdValid(true);
+    } else {
+      setUserIdValid(false);
+      setIdWarningMsg('* 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.');
+    }
+
+    if (userName.length < 2 || userName.length > 10) {
+      setUserNameValid(false);
+      setNameWarningMsg('* 2~10자 이내로 입력해주세요');
+    } else {
+      setUserNameValid(true);
+    }
+  }, [userID, userName]);
 
   // 소개 textarea 높이
-  const textareaRef = useRef(null);
   const handleResizeHeight = () => {
     textareaRef.current.style.height = `38px`;
     textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
@@ -21,6 +48,16 @@ function ProfileSetting() {
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
   }, []);
+
+  const handleUserID = (e) => {
+    setUserID(e.target.value);
+  };
+  const handleUserName = (e) => {
+    setUserName(e.target.value);
+  };
+  const handleIntro = (e) => {
+    setIntro(e.target.value);
+  };
 
   return (
     <S.Container>
@@ -35,6 +72,10 @@ function ProfileSetting() {
             type: 'text',
             placeholder: '아이디를 입력해주세요',
           }}
+          handleProfileState={handleUserID}
+          inputValue={userID}
+          profileValid={userIdValid}
+          warningMsg={idWarningMsg}
         />
         <AuthInputForm
           id="name"
@@ -43,6 +84,10 @@ function ProfileSetting() {
             type: 'text',
             placeholder: '이름을 입력해주세요',
           }}
+          handleProfileState={handleUserName}
+          inputValue={userName}
+          profileValid={userNameValid}
+          warningMsg={nameWarningMsg}
         />
         <S.IntroFormContainer>
           <S.Label htmlFor="intro">소개</S.Label>
@@ -56,6 +101,8 @@ function ProfileSetting() {
             wrap="hard"
             ref={textareaRef}
             onInput={handleResizeHeight}
+            value={intro}
+            onChange={handleIntro}
           />
         </S.IntroFormContainer>
         <S.JoinButton text="후키 시작하기" buttonStyle={LARGE_BUTTON} />

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -83,6 +83,7 @@ function ProfileSetting() {
   const handleStartClick = useCallback(
     async (e) => {
       e.preventDefault();
+      const imageSrc = JSON.parse(localStorage.getItem('image'));
 
       try {
         const res = await authAxios.post('/accountnamevalid', {
@@ -94,12 +95,34 @@ function ProfileSetting() {
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
           setAccountNameValid(false);
           setAccountNameWarningMsg('* 이미 가입된 계정ID 입니다.');
+          inputRef.current.focus();
+        } else {
+          const response = await authAxios.post('/', {
+            user: {
+              username: userName,
+              email: state.email,
+              password: state.password,
+              accountname: accountName,
+              intro,
+              image: imageSrc,
+            },
+          });
+
+          console.log(response.data.user);
+          if (response.data.message === '회원가입 성공') {
+            const userData = response.data.user;
+            const { accountname } = userData;
+
+            localStorage.setItem('accountName', JSON.stringify(accountname));
+
+            navigate('/welcome');
+          }
         }
       } catch (error) {
         console.log(error);
       }
     },
-    [buttonNotAllow]
+    [userName, accountName, intro]
   );
 
   return (

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './index.style';
 import Title from '../../../components/Title';
@@ -9,7 +9,13 @@ import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 function ProfileSetting() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  console.log(state);
+
+  // 소개 textarea 높이
+  const textareaRef = useRef(null);
+  const handleResizeHeight = () => {
+    textareaRef.current.style.height = `38px`;
+    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+  };
 
   // 이메일, 비밀번호 정보 없는 상태에서 URL에 /signup/profile하면 회원가입 페이지로 이동
   useEffect(() => {
@@ -38,14 +44,20 @@ function ProfileSetting() {
             placeholder: '이름을 입력해주세요',
           }}
         />
-        <AuthInputForm
-          id="intro"
-          label="소개"
-          inputProps={{
-            type: 'text',
-            placeholder: '소개글을 작성해주세요',
-          }}
-        />
+        <S.IntroFormContainer>
+          <S.Label htmlFor="intro">소개</S.Label>
+          <S.IntroContent
+            id="intro"
+            name="intro"
+            placeholder="소개글을 입력해주세요"
+            rows={1}
+            cols={20}
+            maxLength={100}
+            wrap="hard"
+            ref={textareaRef}
+            onInput={handleResizeHeight}
+          />
+        </S.IntroFormContainer>
         <S.JoinButton text="후키 시작하기" buttonStyle={LARGE_BUTTON} />
       </S.FormContainer>
     </S.Container>

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -16,6 +16,7 @@ function ProfileSetting() {
   const [accountName, setAccountName] = useState('');
   const [userName, setUserName] = useState('');
   const [intro, setIntro] = useState('');
+  const [image, setImage] = useState('');
 
   const [accountNameValid, setAccountNameValid] = useState(false);
   const [userNameValid, setUserNameValid] = useState(false);
@@ -33,6 +34,11 @@ function ProfileSetting() {
   };
   const handleIntro = (e) => {
     setIntro(e.target.value);
+  };
+
+  // 자식 컴포넌트에서 이미지 src 가져오기
+  const handleProfileImage = (targetImage) => {
+    setImage(targetImage);
   };
 
   // 인풋창 입력할 때마다 유효성 검사
@@ -83,7 +89,6 @@ function ProfileSetting() {
   const handleStartClick = useCallback(
     async (e) => {
       e.preventDefault();
-      const imageSrc = JSON.parse(localStorage.getItem('image'));
 
       try {
         const res = await authAxios.post('/accountnamevalid', {
@@ -104,7 +109,7 @@ function ProfileSetting() {
               password: state.password,
               accountname: accountName,
               intro,
-              image: imageSrc,
+              image: `https://mandarin.api.weniv.co.kr/${image}`,
             },
           });
 
@@ -129,7 +134,7 @@ function ProfileSetting() {
     <S.Container>
       <Title>프로필 설정</Title>
       <S.SubText>나중에 언제든지 변경할 수 있습니다.</S.SubText>
-      <ProfileImageInput />
+      <ProfileImageInput handleProfileImage={handleProfileImage} />
       <S.FormContainer>
         <AuthInputForm
           id="id"

--- a/src/pages/Auth/ProfileSetting/index.style.js
+++ b/src/pages/Auth/ProfileSetting/index.style.js
@@ -34,7 +34,7 @@ export const IntroContent = styled.textarea`
   margin-top: 0.7rem;
   padding: 1.2rem 1.5rem;
   word-wrap: break-word;
-  font-family: 'LINESeedKR-Rg';
+  font-family: Arial;
   border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
   border-radius: ${({ theme }) => theme.borderRadius.BASE};
   font-size: ${({ theme }) => theme.fontSize.MEDIUM};

--- a/src/pages/Auth/ProfileSetting/index.style.js
+++ b/src/pages/Auth/ProfileSetting/index.style.js
@@ -22,4 +22,27 @@ export const FormContainer = styled.form`
   width: 100%;
 `;
 
+export const IntroFormContainer = styled.div``;
+
+export const Label = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+`;
+
+export const IntroContent = styled.textarea`
+  display: block;
+  width: 100%;
+  margin-top: 0.7rem;
+  padding: 1.2rem 1.5rem;
+  word-wrap: break-word;
+  font-family: 'LINESeedKR-Rg';
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.DARK_GRAY};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  }
+`;
+
 export const JoinButton = styled(Button)``;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -47,10 +47,11 @@ const SEmptyContent = styled.p`
 
 function Home() {
   const [isSearch, setIsSearch] = useState(false);
+  const accountname = JSON.parse(localStorage.getItem('accountName'));
 
   const fetchPost = async () => {
     const { data } = await axios.get(
-      'https://mandarin.api.weniv.co.kr/post/Test/userpost',
+      `https://mandarin.api.weniv.co.kr/post/${accountname}/userpost`,
       {
         headers: {
           Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- 회원가입 후 프로필 설정하는 페이지 기능 구현


## 💬 기대 결과
- 프로필 이미지 누르면 이미지 설정
- 프로필 이미지 설정 후 취소하면 기본 이미지로 변경
- 아이디와 이름 입력해야 버튼 활성화 (기본 비활성화, 소개는 필수가 아니라 비어있어도 가능)
- 인풋 입력 시 유효성 검사
  - 아이디: 2~16자 이내 영문, 숫자, (_), (.)
  - 이름: 2~10자 이내
- 버튼 클릭 시 계정 검증

## 💬 전달사항
- 기존 로컬스토리지에 저장한 어카운트네임, 토큰, 이미지소스 중 이미지 소스는 제거
- 프로필 설정 후에 어카운트 네임 저장
- 로그인 완료하면 토큰 저장
- 회원가입 후에 토큰이 없는 상태라 home 페이지로 갈 수 없음, 일단 welcome 페이지로 설정
- 서버에 데이터 전송할 때 소개 입력에 개행이 포함된 값이 들어가게 작업했는데, 받을 때 어떻게 나오는지 보고 수정할 가능성(o) 


## 💬 스크린샷
![setProfile_1](https://user-images.githubusercontent.com/101461874/209110580-acd1eefd-c615-4cbe-b3d6-92362565ddd4.gif)



## 💬 Issue Number
close : #76 