### PR TITLE
팔로워 페이지 팔로우/언팔로우 기능 구현

### DIFF
--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -5,6 +5,7 @@ import Button from '../common/Button';
 import { FOLLOW_BUTTON } from '../../constants/buttonStyle';
 
 import { slEllipsis } from '../../styles/Util';
+import basicProfileImage from '../../assets/basic-profile.png';
 
 const SContent = styled.div`
   display: flex;
@@ -50,9 +51,13 @@ const SButton = styled(Button)`
 `;
 
 function FollowerItem({ data }) {
+  const handleErrorImage = (e) => {
+    e.target.src = basicProfileImage;
+  };
+
   return (
     <SContent key={data.username}>
-      <SImg src={data.image} alt="프로필 이미지" />
+      <SImg src={data.image} alt="프로필 이미지" onError={handleErrorImage} />
       <SUserInfo>
         <SUserId>
           {data.username}

--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import Button from '../common/Button';
@@ -51,6 +51,13 @@ const SButton = styled(Button)`
 `;
 
 function FollowerItem({ data }) {
+  const [followState, setFollowState] = useState(data.isfollow);
+
+  const handleIsFollow = () => {
+    console.log(data);
+    return followState ? setFollowState(false) : setFollowState(true);
+  };
+
   const handleErrorImage = (e) => {
     e.target.src = basicProfileImage;
   };
@@ -65,10 +72,19 @@ function FollowerItem({ data }) {
         </SUserId>
         <SUserIntroduction>{data.intro}</SUserIntroduction>
       </SUserInfo>
-      {data.isfollow ? (
-        <SButton text="취소" buttonStyle={FOLLOW_BUTTON} cancel />
+      {followState ? (
+        <SButton
+          text="취소"
+          buttonStyle={FOLLOW_BUTTON}
+          onClick={handleIsFollow}
+          cancel
+        />
       ) : (
-        <SButton text="팔로우" buttonStyle={FOLLOW_BUTTON} />
+        <SButton
+          text="팔로우"
+          buttonStyle={FOLLOW_BUTTON}
+          onClick={handleIsFollow}
+        />
       )}
     </SContent>
   );

--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -30,6 +30,12 @@ const SUserId = styled.p`
   ${slEllipsis}
 `;
 
+const SAccountName = styled.span`
+  font-size: 1rem;
+  margin-left: 0.5rem;
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
 const SUserIntroduction = styled.p`
   flex: 4 4 0;
   font-size: ${({ theme }) => theme.fontSize.SMALL};
@@ -48,7 +54,10 @@ function FollowerItem({ data }) {
     <SContent key={data.username}>
       <SImg src={data.image} alt="프로필 이미지" />
       <SUserInfo>
-        <SUserId>{data.username}</SUserId>
+        <SUserId>
+          {data.username}
+          <SAccountName>@{data.accountname}</SAccountName>
+        </SUserId>
         <SUserIntroduction>{data.intro}</SUserIntroduction>
       </SUserInfo>
       {data.isfollow ? (

--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 
 import Button from '../common/Button';
 import { FOLLOW_BUTTON } from '../../constants/buttonStyle';
@@ -53,9 +54,31 @@ const SButton = styled(Button)`
 function FollowerItem({ data }) {
   const [followState, setFollowState] = useState(data.isfollow);
 
+  const deleteFollowItem = async () => {
+    try {
+      await axios.delete(
+        `https://mandarin.api.weniv.co.kr/profile/${data.accountname}/unfollow`,
+        {
+          headers: {
+            Authorization: `Bearer ${JSON.parse(
+              localStorage.getItem('token')
+            )}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const handleIsFollow = () => {
-    console.log(data);
-    return followState ? setFollowState(false) : setFollowState(true);
+    if (followState) {
+      deleteFollowItem();
+      setFollowState(false);
+    } else {
+      setFollowState(true);
+    }
   };
 
   const handleErrorImage = (e) => {

--- a/src/components/FollowerItem/index.jsx
+++ b/src/components/FollowerItem/index.jsx
@@ -72,11 +72,31 @@ function FollowerItem({ data }) {
     }
   };
 
+  const postFollowItem = async () => {
+    try {
+      await axios.post(
+        `https://mandarin.api.weniv.co.kr/profile/${data.accountname}/follow`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${JSON.parse(
+              localStorage.getItem('token')
+            )}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const handleIsFollow = () => {
     if (followState) {
       deleteFollowItem();
       setFollowState(false);
     } else {
+      postFollowItem();
       setFollowState(true);
     }
   };

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -51,8 +51,6 @@ function Follower() {
     fetchFollowerList();
   }, []);
 
-  console.log(followerData);
-
   return (
     <>
       <BaseHeader


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가
  - 프로필 액박 이미지 -> 후키 기본 프로필 이미지로 대체
  - 언팔로우/팔로우 기능 구현
- [x] 마크업 & 스타일 : 팔로워 유저 정보에 accountname 데이터 추가

## 💬 전달사항
- 이얏호! 성공한 것 같습니다! 코드 보시고 리뷰 남겨주세요 😄 


## 💬 스크린샷
![화면 기록 2022-12-22 19 46 53](https://user-images.githubusercontent.com/74060716/209119440-bafc25f1-1697-4d45-82cd-1a9d20e27b93.gif)

## 💬 Issue Number
close : #78 
