### PR TITLE
프로필 페이지 UI 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,7 +40,6 @@ function App() {
           <Route path="edit/:id" element={<PostEdit />} />
         </Route>
         <Route path="/profile">
-          <Route index element={<Profile />} />
           <Route path=":id" element={<Profile />} />
           <Route path="edit" element={<ProfileEdit />} />
           <Route path="follower" element={<Follower />} />

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const fetcher = axios.create({
+  baseURL: 'https://mandarin.api.weniv.co.kr',
+});
+
+const getProfileInfo = async (accountName) => {
+  const { data } = await fetcher.get(`/profile/${accountName}`, {
+    headers: {
+      Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+      'Content-type': 'application/json',
+    },
+  });
+  return data;
+};
+
+export default getProfileInfo;

--- a/src/components/Post/PostItem/index.jsx
+++ b/src/components/Post/PostItem/index.jsx
@@ -124,7 +124,7 @@ function PostItem({
           <img src={author.image} alt="프로필 이미지" />
           <S.TextBox>
             <S.UserName>{author.username}</S.UserName>
-            <S.AccountName>{author.accountname}</S.AccountName>
+            <S.AccountName>@{author.accountname}</S.AccountName>
           </S.TextBox>
         </S.UserInfoContainer>
         <S.Contents detail={detail}>

--- a/src/components/Post/PostList/index.jsx
+++ b/src/components/Post/PostList/index.jsx
@@ -10,7 +10,10 @@ const SPostList = styled.ul`
   align-items: center;
 
   width: 100%;
-  gap: 2rem;
+  gap: 1rem;
+
+  padding: 1rem;
+  padding-bottom: 7rem;
 `;
 
 function PostList({ postData }) {

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -4,6 +4,7 @@ import * as S from './index.styles';
 import { MEDIUM_BUTTON } from '../../../constants/buttonStyle';
 import chatIcon from '../../../assets/icon/icon-message-circle-1.png';
 import shareIcon from '../../../assets/icon/icon-share.png';
+import basicProfileImage from '../../../assets/basic-profile.png';
 
 function UserInfo({
   followerCount,
@@ -12,7 +13,13 @@ function UserInfo({
   userName,
   accountName,
   intro,
+  isFollow,
+  isMyPage,
 }) {
+  const handleErrorImage = (e) => {
+    e.target.src = basicProfileImage;
+  };
+
   return (
     <S.UserInfoContainer>
       <S.FollowInfoContainer>
@@ -20,7 +27,11 @@ function UserInfo({
           <S.FollowCount>{followerCount}</S.FollowCount>
           <S.FollowType>followers</S.FollowType>
         </S.FollowInfo>
-        <S.ProfileImage src={profileImage} alt="프로필 이미지" />
+        <S.ProfileImage
+          src={profileImage}
+          alt="프로필 이미지"
+          onError={handleErrorImage}
+        />
         <S.FollowInfo>
           <S.FollowCount>{followingCount}</S.FollowCount>
           <S.FollowType>followings</S.FollowType>
@@ -30,15 +41,34 @@ function UserInfo({
       <S.AccountName>@{accountName}</S.AccountName>
       <S.Intro>{intro}</S.Intro>
       <S.ButtonContainer>
-        <S.IconButton>
-          <img src={chatIcon} alt="채팅 아이콘" />
-        </S.IconButton>
-        <S.FollowButton text="팔로우" buttonStyle={MEDIUM_BUTTON}>
-          팔로우
-        </S.FollowButton>
-        <S.IconButton>
-          <img src={shareIcon} alt="공유 아이콘" />
-        </S.IconButton>
+        {isMyPage ? (
+          <>
+            <S.FollowButton
+              text="프로필 수정"
+              buttonStyle={MEDIUM_BUTTON}
+              cancel
+            />
+            <S.FollowButton
+              text="myPick 등록"
+              buttonStyle={MEDIUM_BUTTON}
+              cancel
+            />
+          </>
+        ) : (
+          <>
+            <S.IconButton>
+              <img src={chatIcon} alt="채팅 아이콘" />
+            </S.IconButton>
+            <S.FollowButton
+              text={isFollow ? '언팔로우' : '팔로우'}
+              buttonStyle={MEDIUM_BUTTON}
+              cancel={isFollow && true}
+            />
+            <S.IconButton>
+              <img src={shareIcon} alt="공유 아이콘" />
+            </S.IconButton>
+          </>
+        )}
       </S.ButtonContainer>
     </S.UserInfoContainer>
   );

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import * as S from './index.styles';
+import { MEDIUM_BUTTON } from '../../../constants/buttonStyle';
+import chatIcon from '../../../assets/icon/icon-message-circle-1.png';
+import shareIcon from '../../../assets/icon/icon-share.png';
+
+function UserInfo({
+  followerCount,
+  profileImage,
+  followingCount,
+  userName,
+  accountName,
+  intro,
+}) {
+  return (
+    <S.UserInfoContainer>
+      <S.FollowInfoContainer>
+        <S.FollowInfo>
+          <S.FollowCount>{followerCount}</S.FollowCount>
+          <S.FollowType>followers</S.FollowType>
+        </S.FollowInfo>
+        <S.ProfileImage src={profileImage} alt="프로필 이미지" />
+        <S.FollowInfo>
+          <S.FollowCount>{followingCount}</S.FollowCount>
+          <S.FollowType>followings</S.FollowType>
+        </S.FollowInfo>
+      </S.FollowInfoContainer>
+      <S.UserName>{userName}</S.UserName>
+      <S.AccountName>@{accountName}</S.AccountName>
+      <S.Intro>{intro}</S.Intro>
+      <S.ButtonContainer>
+        <S.IconButton>
+          <img src={chatIcon} alt="채팅 아이콘" />
+        </S.IconButton>
+        <S.FollowButton text="팔로우" buttonStyle={MEDIUM_BUTTON}>
+          팔로우
+        </S.FollowButton>
+        <S.IconButton>
+          <img src={shareIcon} alt="공유 아이콘" />
+        </S.IconButton>
+      </S.ButtonContainer>
+    </S.UserInfoContainer>
+  );
+}
+
+export default UserInfo;

--- a/src/components/Profile/UserInfo/index.styles.js
+++ b/src/components/Profile/UserInfo/index.styles.js
@@ -9,6 +9,7 @@ export const UserInfoContainer = styled.div`
   align-items: center;
 
   width: 100%;
+  background-color: ${({ theme }) => theme.color.WHITE};
 `;
 
 export const FollowInfoContainer = styled.div`
@@ -72,6 +73,7 @@ export const ButtonContainer = styled.div`
   align-items: center;
 
   gap: 1rem;
+  padding-bottom: 2rem;
 `;
 
 export const IconButton = styled.button`

--- a/src/components/Profile/UserInfo/index.styles.js
+++ b/src/components/Profile/UserInfo/index.styles.js
@@ -1,0 +1,94 @@
+import styled from 'styled-components';
+
+import Button from '../../common/Button';
+
+export const UserInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+`;
+
+export const FollowInfoContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  width: 100%;
+  padding: 3rem 5.4rem 1.5rem 5.4rem;
+`;
+
+export const FollowInfo = styled.div`
+  text-align: center;
+`;
+
+export const FollowCount = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.LARGE};
+  font-family: LINESeedKR-Bd;
+
+  margin-bottom: 0.3rem;
+`;
+
+export const FollowType = styled.p`
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
+export const ProfileImage = styled.img`
+  min-width: 11rem;
+  width: 11rem;
+  min-height: 11rem;
+  height: 11rem;
+
+  object-fit: cover;
+
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+export const UserName = styled.p`
+  font-size: 1.6rem;
+  font-family: LINESeedKR-Bd;
+
+  padding-bottom: 0.6rem;
+`;
+
+export const AccountName = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
+  color: ${({ theme }) => theme.color.GRAY};
+
+  padding-bottom: 1.5rem;
+`;
+
+export const Intro = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+
+  padding: 0rem 5rem 2.4rem 5rem;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  gap: 1rem;
+`;
+
+export const IconButton = styled.button`
+  min-width: 3.4rem;
+  width: 3.4rem;
+  min-height: 3.4rem;
+  height: 3.4rem;
+
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+
+  img {
+    width: 1.5rem;
+  }
+`;
+
+export const FollowButton = styled(Button)`
+  width: 12rem;
+  height: 3.4rem;
+`;

--- a/src/components/common/Navigation/index.jsx
+++ b/src/components/common/Navigation/index.jsx
@@ -29,6 +29,7 @@ const SContainer = styled.div`
 
 function Navigation() {
   const [currentPath, setCurrentPath] = useRecoilState(pathState);
+  const accountName = JSON.parse(localStorage.getItem('accountName'));
 
   const handlePathChange = (path) => {
     setCurrentPath(path);
@@ -55,10 +56,10 @@ function Navigation() {
         onClick={() => handlePathChange('/post/upload')}
       />
       <NavigationLink
-        path="/profile"
-        icon={currentPath === '/profile' ? filledProfileIcon : profileIcon}
+        path={`/profile/${accountName}`}
+        icon={currentPath.includes('profile') ? filledProfileIcon : profileIcon}
         linkName="프로필"
-        onClick={() => handlePathChange('/profile')}
+        onClick={() => handlePathChange(`/profile/${accountName}`)}
       />
     </SContainer>
   );

--- a/src/pages/Home/index.styles.js
+++ b/src/pages/Home/index.styles.js
@@ -5,9 +5,6 @@ export const Container = styled.main`
   flex-direction: column;
   align-items: center;
   height: calc(100 + 4.4) vh;
-
-  padding: 0.9rem;
-  margin-bottom: 6rem;
 `;
 
 export const EmptyContainer = styled.section`

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,15 +1,39 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { useQuery } from 'react-query';
+
+import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
+import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
+import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
+
+import getProfileInfo from '../../api/profile';
 
 function Profile() {
   const param = useParams();
   console.log(param);
+
+  const { data, isLoading, isError } = useQuery('profileInfo', () =>
+    getProfileInfo(param.id)
+  );
+
+  if (!isLoading) {
+    console.log(data.profile);
+  }
+
   return (
-    <div>
-      Profile
+    <>
+      <BaseHeader
+        leftIcon={leftArrowIcon}
+        leftClick={() => {}}
+        rightIcon={verticalIcon}
+        rightAlt="프로필 설정"
+        rightClick={() => {}}
+      />
+      {!isLoading && <div>{data.profile.accountname}</div>}
+
       <Navigation />
-    </div>
+    </>
   );
 }
 

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
@@ -7,103 +6,9 @@ import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
-import chatIcon from '../../assets/icon/icon-message-circle-1.png';
-import shareIcon from '../../assets/icon/icon-share.png';
-import Button from '../../components/common/Button';
-import { MEDIUM_BUTTON } from '../../constants/buttonStyle';
 
 import getProfileInfo from '../../api/profile';
-
-const SUserInfoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-`;
-
-const SFollowInfoContainer = styled.div`
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-
-  width: 100%;
-  padding: 3rem 5.4rem 1.5rem 5.4rem;
-`;
-
-const SFollowInfo = styled.div`
-  text-align: center;
-`;
-
-const SFollowCount = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.LARGE};
-  font-family: LINESeedKR-Bd;
-
-  margin-bottom: 0.3rem;
-`;
-
-const SFollowType = styled.p`
-  color: ${({ theme }) => theme.color.GRAY};
-`;
-
-const SProfileImage = styled.img`
-  min-width: 11rem;
-  width: 11rem;
-  min-height: 11rem;
-  height: 11rem;
-
-  object-fit: cover;
-
-  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
-`;
-
-const SUserName = styled.p`
-  font-size: 1.6rem;
-  font-family: LINESeedKR-Bd;
-
-  padding-bottom: 0.6rem;
-`;
-
-const SAccountName = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.SMALL};
-  color: ${({ theme }) => theme.color.GRAY};
-
-  padding-bottom: 1.5rem;
-`;
-
-const SIntro = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  color: ${({ theme }) => theme.color.GRAY};
-
-  padding: 0rem 5rem 2.4rem 5rem;
-`;
-
-const SButtonContainer = styled.div`
-  display: flex;
-  align-items: center;
-
-  gap: 1rem;
-`;
-
-const SIconButton = styled.button`
-  min-width: 3.4rem;
-  width: 3.4rem;
-  min-height: 3.4rem;
-  height: 3.4rem;
-
-  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
-
-  img {
-    width: 1.5rem;
-  }
-`;
-
-const FollowButton = styled(Button)`
-  width: 12rem;
-  height: 3.4rem;
-`;
+import UserInfo from '../../components/Profile/UserInfo';
 
 function Profile() {
   const param = useParams();
@@ -127,33 +32,14 @@ function Profile() {
         rightClick={() => {}}
       />
       {!isLoading && (
-        <SUserInfoContainer>
-          <SFollowInfoContainer>
-            <SFollowInfo>
-              <SFollowCount>{data.profile.followerCount}</SFollowCount>
-              <SFollowType>followers</SFollowType>
-            </SFollowInfo>
-            <SProfileImage src={data.profile.image} alt="프로필 이미지" />
-            <SFollowInfo>
-              <SFollowCount>{data.profile.followingCount}</SFollowCount>
-              <SFollowType>followings</SFollowType>
-            </SFollowInfo>
-          </SFollowInfoContainer>
-          <SUserName>{data.profile.username}</SUserName>
-          <SAccountName>@{data.profile.accountname}</SAccountName>
-          <SIntro>{data.profile.intro}</SIntro>
-          <SButtonContainer>
-            <SIconButton>
-              <img src={chatIcon} alt="채팅 아이콘" />
-            </SIconButton>
-            <FollowButton text="팔로우" buttonStyle={MEDIUM_BUTTON}>
-              팔로우
-            </FollowButton>
-            <SIconButton>
-              <img src={shareIcon} alt="공유 아이콘" />
-            </SIconButton>
-          </SButtonContainer>
-        </SUserInfoContainer>
+        <UserInfo
+          followerCount={data.profile.followerCount}
+          followingCount={data.profile.followingCount}
+          profileImage={data.profile.image}
+          userName={data.profile.username}
+          accountName={data.profile.accountname}
+          intro={data.profile.intro}
+        />
       )}
 
       <Navigation />

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import Navigation from '../../components/common/Navigation';
 
 function Profile() {
+  const param = useParams();
+  console.log(param);
   return (
     <div>
       Profile

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -9,12 +9,16 @@ import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
 import UserInfo from '../../components/Profile/UserInfo';
 import PostList from '../../components/Post/PostList';
-
-import getProfileInfo from '../../api/profile';
-import { getMyPost } from '../../api/post';
 import { LARGE_BUTTON } from '../../constants/buttonStyle';
 import logoGrey from '../../assets/logo_grey.png';
 import Button from '../../components/common/Button';
+import postListOnIcon from '../../assets/icon/icon-post-list-on.png';
+import postListOffIcon from '../../assets/icon/icon-post-list-off.png';
+import postAlbumOnIcon from '../../assets/icon/icon-post-album-on.png';
+import postAlbumOffIcon from '../../assets/icon/icon-post-album-off.png';
+
+import getProfileInfo from '../../api/profile';
+import { getMyPost } from '../../api/post';
 
 function Profile() {
   const param = useParams();
@@ -56,15 +60,25 @@ function Profile() {
             isMyPage={isMyPage}
           />
         )}
-        {myPost?.length > 0 ? (
-          <PostList postData={myPost} />
-        ) : (
-          <S.EmptyContainer>
-            <S.EmptyImage src={logoGrey} alt="로고 이미지" />
-            <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
-            <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
-          </S.EmptyContainer>
-        )}
+        <S.PostContainer>
+          <S.PostTypeContainer>
+            <S.PostTypeButton>
+              <img src={postListOnIcon} alt="리스트형 포스트" />
+            </S.PostTypeButton>
+            <S.PostTypeButton>
+              <img src={postAlbumOnIcon} alt="앨범형 포스트" />
+            </S.PostTypeButton>
+          </S.PostTypeContainer>
+          {myPost?.post.length > 0 ? (
+            <PostList postData={myPost.post} myPage />
+          ) : (
+            <S.EmptyContainer>
+              <S.EmptyImage src={logoGrey} alt="로고 이미지" />
+              <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
+              <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
+            </S.EmptyContainer>
+          )}
+        </S.PostContainer>
       </S.Container>
 
       <Navigation />

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
@@ -6,8 +7,103 @@ import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
+import chatIcon from '../../assets/icon/icon-message-circle-1.png';
+import shareIcon from '../../assets/icon/icon-share.png';
+import Button from '../../components/common/Button';
+import { MEDIUM_BUTTON } from '../../constants/buttonStyle';
 
 import getProfileInfo from '../../api/profile';
+
+const SUserInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+`;
+
+const SFollowInfoContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  width: 100%;
+  padding: 3rem 5.4rem 1.5rem 5.4rem;
+`;
+
+const SFollowInfo = styled.div`
+  text-align: center;
+`;
+
+const SFollowCount = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.LARGE};
+  font-family: LINESeedKR-Bd;
+
+  margin-bottom: 0.3rem;
+`;
+
+const SFollowType = styled.p`
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
+const SProfileImage = styled.img`
+  min-width: 11rem;
+  width: 11rem;
+  min-height: 11rem;
+  height: 11rem;
+
+  object-fit: cover;
+
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+`;
+
+const SUserName = styled.p`
+  font-size: 1.6rem;
+  font-family: LINESeedKR-Bd;
+
+  padding-bottom: 0.6rem;
+`;
+
+const SAccountName = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.SMALL};
+  color: ${({ theme }) => theme.color.GRAY};
+
+  padding-bottom: 1.5rem;
+`;
+
+const SIntro = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+
+  padding: 0rem 5rem 2.4rem 5rem;
+`;
+
+const SButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  gap: 1rem;
+`;
+
+const SIconButton = styled.button`
+  min-width: 3.4rem;
+  width: 3.4rem;
+  min-height: 3.4rem;
+  height: 3.4rem;
+
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.ROUND};
+
+  img {
+    width: 1.5rem;
+  }
+`;
+
+const FollowButton = styled(Button)`
+  width: 12rem;
+  height: 3.4rem;
+`;
 
 function Profile() {
   const param = useParams();
@@ -30,7 +126,35 @@ function Profile() {
         rightAlt="프로필 설정"
         rightClick={() => {}}
       />
-      {!isLoading && <div>{data.profile.accountname}</div>}
+      {!isLoading && (
+        <SUserInfoContainer>
+          <SFollowInfoContainer>
+            <SFollowInfo>
+              <SFollowCount>{data.profile.followerCount}</SFollowCount>
+              <SFollowType>followers</SFollowType>
+            </SFollowInfo>
+            <SProfileImage src={data.profile.image} alt="프로필 이미지" />
+            <SFollowInfo>
+              <SFollowCount>{data.profile.followingCount}</SFollowCount>
+              <SFollowType>followings</SFollowType>
+            </SFollowInfo>
+          </SFollowInfoContainer>
+          <SUserName>{data.profile.username}</SUserName>
+          <SAccountName>@{data.profile.accountname}</SAccountName>
+          <SIntro>{data.profile.intro}</SIntro>
+          <SButtonContainer>
+            <SIconButton>
+              <img src={chatIcon} alt="채팅 아이콘" />
+            </SIconButton>
+            <FollowButton text="팔로우" buttonStyle={MEDIUM_BUTTON}>
+              팔로우
+            </FollowButton>
+            <SIconButton>
+              <img src={shareIcon} alt="공유 아이콘" />
+            </SIconButton>
+          </SButtonContainer>
+        </SUserInfoContainer>
+      )}
 
       <Navigation />
     </>

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -6,13 +6,14 @@ import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
+import UserInfo from '../../components/Profile/UserInfo';
 
 import getProfileInfo from '../../api/profile';
-import UserInfo from '../../components/Profile/UserInfo';
+import { getMyPost } from '../../api/post';
 
 function Profile() {
   const param = useParams();
-  console.log(param);
+  const isMyPage = param.id === JSON.parse(localStorage.getItem('accountName'));
 
   const { data, isLoading, isError } = useQuery('profileInfo', () =>
     getProfileInfo(param.id)
@@ -39,6 +40,8 @@ function Profile() {
           userName={data.profile.username}
           accountName={data.profile.accountname}
           intro={data.profile.intro}
+          isFollow={data.profile.isfollow}
+          isMyPage={isMyPage}
         />
       )}
 

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
+import * as S from './index.styles';
 import BaseHeader from '../../components/common/BaseHeader';
 import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
 import UserInfo from '../../components/Profile/UserInfo';
+import PostList from '../../components/Post/PostList';
 
 import getProfileInfo from '../../api/profile';
 import { getMyPost } from '../../api/post';
+import { LARGE_BUTTON } from '../../constants/buttonStyle';
+import logoGrey from '../../assets/logo_grey.png';
+import Button from '../../components/common/Button';
 
 function Profile() {
   const param = useParams();
@@ -18,6 +23,12 @@ function Profile() {
   const { data, isLoading, isError } = useQuery('profileInfo', () =>
     getProfileInfo(param.id)
   );
+
+  const {
+    data: myPost,
+    isLoading: isMyPostLoading,
+    isError: isMyPostError,
+  } = useQuery('myPostList', getMyPost);
 
   if (!isLoading) {
     console.log(data.profile);
@@ -32,18 +43,29 @@ function Profile() {
         rightAlt="프로필 설정"
         rightClick={() => {}}
       />
-      {!isLoading && (
-        <UserInfo
-          followerCount={data.profile.followerCount}
-          followingCount={data.profile.followingCount}
-          profileImage={data.profile.image}
-          userName={data.profile.username}
-          accountName={data.profile.accountname}
-          intro={data.profile.intro}
-          isFollow={data.profile.isfollow}
-          isMyPage={isMyPage}
-        />
-      )}
+      <S.Container>
+        {!isLoading && (
+          <UserInfo
+            followerCount={data.profile.followerCount}
+            followingCount={data.profile.followingCount}
+            profileImage={data.profile.image}
+            userName={data.profile.username}
+            accountName={data.profile.accountname}
+            intro={data.profile.intro}
+            isFollow={data.profile.isfollow}
+            isMyPage={isMyPage}
+          />
+        )}
+        {myPost?.length > 0 ? (
+          <PostList postData={myPost} />
+        ) : (
+          <S.EmptyContainer>
+            <S.EmptyImage src={logoGrey} alt="로고 이미지" />
+            <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
+            <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
+          </S.EmptyContainer>
+        )}
+      </S.Container>
 
       <Navigation />
     </>

--- a/src/pages/Profile/index.styles.js
+++ b/src/pages/Profile/index.styles.js
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+export const Container = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+
+  gap: 0.6rem;
+
+  background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+export const EmptyContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  background-color: ${({ theme }) => theme.color.WHITE};
+
+  padding: 3rem 0rem 10rem 0rem;
+
+  button {
+    width: 12rem;
+  }
+`;
+
+export const EmptyImage = styled.img`
+  width: 20rem;
+  margin-bottom: 2.6rem;
+`;
+
+export const EmptyContent = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+  margin-bottom: 2rem;
+`;

--- a/src/pages/Profile/index.styles.js
+++ b/src/pages/Profile/index.styles.js
@@ -11,7 +11,31 @@ export const Container = styled.main`
   background-color: ${({ theme }) => theme.color.LIGHT_GRAY};
 `;
 
-export const EmptyContainer = styled.section`
+export const PostContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 100%;
+  background-color: ${({ theme }) => theme.color.WHITE};
+`;
+
+export const PostTypeContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  padding: 1rem 1.5rem;
+  gap: 2rem;
+  width: 100%;
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+export const PostTypeButton = styled.button`
+  width: 2.5rem;
+`;
+
+export const EmptyContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : UI 디자인을 위한 myPost API 호출
- [x] 마크업 & 스타일 : 프로필 페이지 UI 구현 (나의 페이지, 타인의 페이지 분리)
- [x] 리팩토링 : API 명세에 맞는 라우트 수정


## 💬 전달사항
- 피그마 디자인에 맞춰 section 사이를 light_gray 색상으로 추가했는데 , 저 색상이 의도된걸까요? 일단 보이는대로 구현했습니다.


## 💬 스크린샷
나의 페이지, 포스트 없을때 (이전 스샷이라 위에 앨범형, 리스트형 없음)
<img width="378" alt="스크린샷 2022-12-24 오후 6 01 42" src="https://user-images.githubusercontent.com/71367408/209430492-d888a97b-db3a-475a-b19c-6e9bce6256cb.png">

나의 페이지, 포스트 있을 때
<img width="377" alt="스크린샷 2022-12-24 오후 6 45 17" src="https://user-images.githubusercontent.com/71367408/209430501-3da6e0be-5878-45a5-91cf-ee91508b2f8e.png">

팔로우 안되있는 계정(test@gmail.com로 본 화면)
<img width="369" alt="image" src="https://user-images.githubusercontent.com/71367408/209430685-7e201e33-cb25-49f0-a4df-93b0af0c0bbc.png">

팔로우 되있는 계정(test@gmail.com로 본 화면)
<img width="372" alt="image" src="https://user-images.githubusercontent.com/71367408/209430703-06680585-0158-4952-aa9b-c242b42b856d.png">



## 💬 Issue Number
close : #89 
