### PR TITLE
프로필 페이지 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,9 +39,9 @@ function App() {
           <Route path="upload" element={<PostUpload />} />
           <Route path="edit/:id" element={<PostEdit />} />
         </Route>
-        <Route path="/profile">
-          <Route path=":id" element={<Profile />} />
-          <Route path="edit" element={<ProfileEdit />} />
+        <Route path="/profile/edit" element={<ProfileEdit />} />
+        <Route path="/profile/:accountname">
+          <Route index element={<Profile />} />
           <Route path="follower" element={<Follower />} />
           <Route path="following" element={<Following />} />
         </Route>

--- a/src/api/follow.js
+++ b/src/api/follow.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+export const postFollow = async (accountName) => {
+  try {
+    await axios.post(
+      `https://mandarin.api.weniv.co.kr/profile/${accountName}/follow`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const deleteFollow = async (accountName) => {
+  try {
+    await axios.delete(
+      `https://mandarin.api.weniv.co.kr/profile/${accountName}/unfollow`,
+      {
+        headers: {
+          Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -4,16 +4,13 @@ const fetcher = axios.create({
   baseURL: 'https://mandarin.api.weniv.co.kr',
 });
 
-export const getMyPost = async () => {
-  const { data } = await fetcher.get(
-    `/post/${JSON.parse(localStorage.getItem('accountName'))}/userpost/`,
-    {
-      headers: {
-        Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
-        'Content-type': 'application/json',
-      },
-    }
-  );
+export const getAccountPost = async (accountName) => {
+  const { data } = await fetcher.get(`/post/${accountName}/userpost/`, {
+    headers: {
+      Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+      'Content-type': 'application/json',
+    },
+  });
   return data;
 };
 

--- a/src/components/Post/AlbumPostItem/index.jsx
+++ b/src/components/Post/AlbumPostItem/index.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import * as S from './index.styles';
+import imageLayerIcon from '../../../assets/icon/icon-img-layers.png';
+
+const AlbumContainer = styled.li`
+  position: relative;
+
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+
+  overflow: hidden;
+`;
+
+const AlbumImage = styled.img`
+  height: 100%;
+
+  object-fit: cover;
+`;
+
+const LayerIcon = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+
+  width: 2rem;
+  height: 2rem;
+
+  background-image: url(${imageLayerIcon});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+`;
+
+function AlbumPostItem({ image }) {
+  const [imageArray, setImageArray] = useState([]);
+
+  useEffect(() => {
+    if (image) {
+      setImageArray(image.split(', '));
+    }
+  }, []);
+
+  return (
+    <>
+      {imageArray.length > 0 && (
+        <AlbumContainer>
+          <AlbumImage
+            src={`https://mandarin.api.weniv.co.kr/${imageArray[0]}`}
+            alt="앨범형 첫번째 이미지"
+          />
+          {imageArray.length > 1 && <LayerIcon />}
+        </AlbumContainer>
+      )}
+    </>
+  );
+}
+
+export default AlbumPostItem;

--- a/src/components/Post/AlbumPostItem/index.jsx
+++ b/src/components/Post/AlbumPostItem/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import * as S from './index.styles';
 
-function AlbumPostItem({ image }) {
+function AlbumPostItem({ postId, image, goPostDetailPage }) {
   const [imageArray, setImageArray] = useState([]);
 
   useEffect(() => {
@@ -14,7 +14,7 @@ function AlbumPostItem({ image }) {
   return (
     <>
       {imageArray.length > 0 && (
-        <S.AlbumContainer>
+        <S.AlbumContainer onClick={() => goPostDetailPage(postId)}>
           <S.AlbumImage
             src={`https://mandarin.api.weniv.co.kr/${imageArray[0]}`}
             alt="앨범형 첫번째 이미지"

--- a/src/components/Post/AlbumPostItem/index.jsx
+++ b/src/components/Post/AlbumPostItem/index.jsx
@@ -1,37 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
 
 import * as S from './index.styles';
-import imageLayerIcon from '../../../assets/icon/icon-img-layers.png';
-
-const AlbumContainer = styled.li`
-  position: relative;
-
-  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  border-radius: ${({ theme }) => theme.borderRadius.BASE};
-
-  overflow: hidden;
-`;
-
-const AlbumImage = styled.img`
-  height: 100%;
-
-  object-fit: cover;
-`;
-
-const LayerIcon = styled.div`
-  position: absolute;
-  top: 0.4rem;
-  right: 0.4rem;
-
-  width: 2rem;
-  height: 2rem;
-
-  background-image: url(${imageLayerIcon});
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: cover;
-`;
 
 function AlbumPostItem({ image }) {
   const [imageArray, setImageArray] = useState([]);
@@ -45,13 +14,13 @@ function AlbumPostItem({ image }) {
   return (
     <>
       {imageArray.length > 0 && (
-        <AlbumContainer>
-          <AlbumImage
+        <S.AlbumContainer>
+          <S.AlbumImage
             src={`https://mandarin.api.weniv.co.kr/${imageArray[0]}`}
             alt="앨범형 첫번째 이미지"
           />
-          {imageArray.length > 1 && <LayerIcon />}
-        </AlbumContainer>
+          {imageArray.length > 1 && <S.LayerIcon />}
+        </S.AlbumContainer>
       )}
     </>
   );

--- a/src/components/Post/AlbumPostItem/index.styles.js
+++ b/src/components/Post/AlbumPostItem/index.styles.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+import imageLayerIcon from '../../../assets/icon/icon-img-layers.png';
+
+export const AlbumContainer = styled.li`
+  position: relative;
+
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+
+  overflow: hidden;
+`;
+
+export const AlbumImage = styled.img`
+  height: 100%;
+
+  object-fit: cover;
+`;
+
+export const LayerIcon = styled.div`
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+
+  width: 2rem;
+  height: 2rem;
+
+  background-image: url(${imageLayerIcon});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+`;

--- a/src/components/Post/PostList/index.jsx
+++ b/src/components/Post/PostList/index.jsx
@@ -37,7 +37,12 @@ function PostList({ postData, isAlbum }) {
       {isAlbum && (
         <S.PostAlbum>
           {postData.map((item) => (
-            <AlbumPostItem key={item.id} image={item.image} />
+            <AlbumPostItem
+              key={item.id}
+              postId={item.id}
+              image={item.image}
+              goPostDetailPage={goPostDetailPage}
+            />
           ))}
         </S.PostAlbum>
       )}

--- a/src/components/Post/PostList/index.jsx
+++ b/src/components/Post/PostList/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import AlbumPostItem from '../AlbumPostItem';
 import PostItem from '../PostItem';
 
 const SPostList = styled.ul`
@@ -16,7 +17,19 @@ const SPostList = styled.ul`
   padding-bottom: 7rem;
 `;
 
-function PostList({ postData }) {
+const SPostAlbum = styled.ul`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-auto-rows: minmax(11rem, 11rem);
+
+  width: 100%;
+  gap: 1rem;
+
+  padding: 1rem;
+  margin-bottom: 7rem;
+`;
+
+function PostList({ postData, isAlbum }) {
   const navigate = useNavigate();
 
   const goPostDetailPage = (id) => {
@@ -24,24 +37,35 @@ function PostList({ postData }) {
   };
 
   return (
-    <SPostList>
-      {postData.map((item) => (
-        <PostItem
-          key={item.id}
-          postId={item.id}
-          content={item.content}
-          image={item.image}
-          createdAt={item.createdAt}
-          updatedAt={item.updatedAt}
-          hearted={item.hearted}
-          heartCount={item.heartCount}
-          comment={item.comment}
-          commentCount={item.commentCount}
-          author={item.author}
-          goPostDetailPage={goPostDetailPage}
-        />
-      ))}
-    </SPostList>
+    <>
+      {!isAlbum && (
+        <SPostList>
+          {postData.map((item) => (
+            <PostItem
+              key={item.id}
+              postId={item.id}
+              content={item.content}
+              image={item.image}
+              createdAt={item.createdAt}
+              updatedAt={item.updatedAt}
+              hearted={item.hearted}
+              heartCount={item.heartCount}
+              comment={item.comment}
+              commentCount={item.commentCount}
+              author={item.author}
+              goPostDetailPage={goPostDetailPage}
+            />
+          ))}
+        </SPostList>
+      )}
+      {isAlbum && (
+        <SPostAlbum>
+          {postData.map((item) => (
+            <AlbumPostItem key={item.id} image={item.image} />
+          ))}
+        </SPostAlbum>
+      )}
+    </>
   );
 }
 

--- a/src/components/Post/PostList/index.jsx
+++ b/src/components/Post/PostList/index.jsx
@@ -1,33 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+
+import * as S from './index.styles';
 import AlbumPostItem from '../AlbumPostItem';
 import PostItem from '../PostItem';
-
-const SPostList = styled.ul`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  gap: 1rem;
-
-  padding: 1rem;
-  padding-bottom: 7rem;
-`;
-
-const SPostAlbum = styled.ul`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-auto-rows: minmax(11rem, 11rem);
-
-  width: 100%;
-  gap: 1rem;
-
-  padding: 1rem;
-  margin-bottom: 7rem;
-`;
 
 function PostList({ postData, isAlbum }) {
   const navigate = useNavigate();
@@ -39,7 +15,7 @@ function PostList({ postData, isAlbum }) {
   return (
     <>
       {!isAlbum && (
-        <SPostList>
+        <S.PostList>
           {postData.map((item) => (
             <PostItem
               key={item.id}
@@ -56,14 +32,14 @@ function PostList({ postData, isAlbum }) {
               goPostDetailPage={goPostDetailPage}
             />
           ))}
-        </SPostList>
+        </S.PostList>
       )}
       {isAlbum && (
-        <SPostAlbum>
+        <S.PostAlbum>
           {postData.map((item) => (
             <AlbumPostItem key={item.id} image={item.image} />
           ))}
-        </SPostAlbum>
+        </S.PostAlbum>
       )}
     </>
   );

--- a/src/components/Post/PostList/index.styles.js
+++ b/src/components/Post/PostList/index.styles.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const PostList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  gap: 1rem;
+
+  padding: 1rem;
+  padding-bottom: 7rem;
+`;
+
+export const PostAlbum = styled.ul`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-auto-rows: minmax(11rem, 11rem);
+
+  width: 100%;
+  gap: 1rem;
+
+  padding: 1rem;
+  margin-bottom: 7rem;
+`;

--- a/src/components/Post/PostList/index.styles.js
+++ b/src/components/Post/PostList/index.styles.js
@@ -22,5 +22,5 @@ export const PostAlbum = styled.ul`
   gap: 1rem;
 
   padding: 1rem;
-  margin-bottom: 7rem;
+  padding-bottom: 10rem;
 `;

--- a/src/components/Profile/ProfilePost/index.jsx
+++ b/src/components/Profile/ProfilePost/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 
 import * as S from './index.styles';
@@ -14,30 +14,49 @@ import { getAccountPost } from '../../../api/post';
 import PostList from '../../Post/PostList';
 
 function ProfilePost({ accountName }) {
+  const [isListPost, setIsListPost] = useState(true);
+
   const { data, isLoading, isError } = useQuery('myPostList', () =>
     getAccountPost(accountName)
   );
 
+  const handleListPost = () => {
+    setIsListPost(true);
+  };
+  const handleAlbumPost = () => {
+    setIsListPost(false);
+  };
+
   return (
-    <S.PostContainer>
-      <S.PostTypeContainer>
-        <S.PostTypeButton>
-          <img src={postListOnIcon} alt="리스트형 포스트" />
-        </S.PostTypeButton>
-        <S.PostTypeButton>
-          <img src={postAlbumOnIcon} alt="앨범형 포스트" />
-        </S.PostTypeButton>
-      </S.PostTypeContainer>
-      {data?.post.length > 0 ? (
-        <PostList postData={data.post} myPage />
-      ) : (
-        <S.EmptyContainer>
-          <S.EmptyImage src={logoGrey} alt="로고 이미지" />
-          <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
-          <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
-        </S.EmptyContainer>
+    <>
+      {!isLoading && (
+        <S.PostContainer>
+          <S.PostTypeContainer>
+            <S.PostTypeButton onClick={handleListPost}>
+              <img
+                src={isListPost ? postListOnIcon : postListOffIcon}
+                alt="리스트형 포스트"
+              />
+            </S.PostTypeButton>
+            <S.PostTypeButton onClick={handleAlbumPost}>
+              <img
+                src={isListPost ? postAlbumOffIcon : postAlbumOnIcon}
+                alt="앨범형 포스트"
+              />
+            </S.PostTypeButton>
+          </S.PostTypeContainer>
+          {data?.post.length > 0 ? (
+            <PostList postData={data.post} isAlbum={!isListPost} />
+          ) : (
+            <S.EmptyContainer>
+              <S.EmptyImage src={logoGrey} alt="로고 이미지" />
+              <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
+              <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
+            </S.EmptyContainer>
+          )}
+        </S.PostContainer>
       )}
-    </S.PostContainer>
+    </>
   );
 }
 

--- a/src/components/Profile/ProfilePost/index.jsx
+++ b/src/components/Profile/ProfilePost/index.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+
+import * as S from './index.styles';
+import logoGrey from '../../../assets/logo_grey.png';
+import postListOnIcon from '../../../assets/icon/icon-post-list-on.png';
+import postListOffIcon from '../../../assets/icon/icon-post-list-off.png';
+import postAlbumOnIcon from '../../../assets/icon/icon-post-album-on.png';
+import postAlbumOffIcon from '../../../assets/icon/icon-post-album-off.png';
+import { LARGE_BUTTON } from '../../../constants/buttonStyle';
+import Button from '../../common/Button';
+
+import { getAccountPost } from '../../../api/post';
+import PostList from '../../Post/PostList';
+
+function ProfilePost({ accountName }) {
+  const { data, isLoading, isError } = useQuery('myPostList', () =>
+    getAccountPost(accountName)
+  );
+
+  return (
+    <S.PostContainer>
+      <S.PostTypeContainer>
+        <S.PostTypeButton>
+          <img src={postListOnIcon} alt="리스트형 포스트" />
+        </S.PostTypeButton>
+        <S.PostTypeButton>
+          <img src={postAlbumOnIcon} alt="앨범형 포스트" />
+        </S.PostTypeButton>
+      </S.PostTypeContainer>
+      {data?.post.length > 0 ? (
+        <PostList postData={data.post} myPage />
+      ) : (
+        <S.EmptyContainer>
+          <S.EmptyImage src={logoGrey} alt="로고 이미지" />
+          <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
+          <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
+        </S.EmptyContainer>
+      )}
+    </S.PostContainer>
+  );
+}
+
+export default ProfilePost;

--- a/src/components/Profile/ProfilePost/index.styles.js
+++ b/src/components/Profile/ProfilePost/index.styles.js
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+export const PostContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 100%;
+  background-color: ${({ theme }) => theme.color.WHITE};
+`;
+
+export const PostTypeContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  padding: 1rem 1.5rem;
+  gap: 2rem;
+  width: 100%;
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+`;
+
+export const PostTypeButton = styled.button`
+  width: 2.5rem;
+`;
+
+export const EmptyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  background-color: ${({ theme }) => theme.color.WHITE};
+
+  padding: 3rem 0rem 10rem 0rem;
+
+  button {
+    width: 12rem;
+  }
+`;
+
+export const EmptyImage = styled.img`
+  width: 20rem;
+  margin-bottom: 2.6rem;
+`;
+
+export const EmptyContent = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+  margin-bottom: 2rem;
+`;

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import * as S from './index.styles';
 import { MEDIUM_BUTTON } from '../../../constants/buttonStyle';
 import chatIcon from '../../../assets/icon/icon-message-circle-1.png';
 import shareIcon from '../../../assets/icon/icon-share.png';
 import basicProfileImage from '../../../assets/basic-profile.png';
+import Snackbar from '../../Modal/SnackBar';
 
 function UserInfo({
   followerCount,
@@ -17,6 +18,8 @@ function UserInfo({
   isFollow,
   isMyPage,
 }) {
+  const [isSnackBarOpen, setIsSnackBarOpen] = useState(false);
+  const [snackBarMessage, setSnackBarMessage] = useState('');
   const navigate = useNavigate();
 
   const handleErrorImage = (e) => {
@@ -37,6 +40,26 @@ function UserInfo({
 
   const goToMyPicksPage = () => {
     navigate(`/mypicks`);
+  };
+
+  const goToChatPage = () => {
+    navigate(`/chat`);
+  };
+
+  const handleSnackBar = () => {
+    setIsSnackBarOpen(true);
+    return setTimeout(() => setIsSnackBarOpen(false), 2000);
+  };
+
+  const copyProfileAddress = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setSnackBarMessage('클립보드에 복사되었습니다.');
+      handleSnackBar();
+    } catch (e) {
+      setSnackBarMessage('복사가 실패했습니다.');
+      handleSnackBar();
+    }
   };
 
   return (
@@ -77,7 +100,7 @@ function UserInfo({
           </>
         ) : (
           <>
-            <S.IconButton>
+            <S.IconButton onClick={goToChatPage}>
               <img src={chatIcon} alt="채팅 아이콘" />
             </S.IconButton>
             <S.FollowButton
@@ -85,12 +108,13 @@ function UserInfo({
               buttonStyle={MEDIUM_BUTTON}
               cancel={isFollow && true}
             />
-            <S.IconButton>
+            <S.IconButton onClick={copyProfileAddress}>
               <img src={shareIcon} alt="공유 아이콘" />
             </S.IconButton>
           </>
         )}
       </S.ButtonContainer>
+      {isSnackBarOpen && <Snackbar content={snackBarMessage} />}
     </S.UserInfoContainer>
   );
 }

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -31,6 +31,14 @@ function UserInfo({
     navigate(`/profile/${accountname}/following`);
   };
 
+  const goToProfileEditPage = () => {
+    navigate(`/profile/edit`);
+  };
+
+  const goToMyPicksPage = () => {
+    navigate(`/mypicks`);
+  };
+
   return (
     <S.UserInfoContainer>
       <S.FollowInfoContainer>
@@ -57,11 +65,13 @@ function UserInfo({
             <S.FollowButton
               text="프로필 수정"
               buttonStyle={MEDIUM_BUTTON}
+              onClick={goToProfileEditPage}
               cancel
             />
             <S.FollowButton
               text="myPick 등록"
               buttonStyle={MEDIUM_BUTTON}
+              onClick={goToMyPicksPage}
               cancel
             />
           </>

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import * as S from './index.styles';
 import { MEDIUM_BUTTON } from '../../../constants/buttonStyle';
@@ -16,14 +17,24 @@ function UserInfo({
   isFollow,
   isMyPage,
 }) {
+  const navigate = useNavigate();
+
   const handleErrorImage = (e) => {
     e.target.src = basicProfileImage;
+  };
+
+  const goToFollowerPage = (accountname) => {
+    navigate(`/profile/${accountname}/follower`);
+  };
+
+  const goToFollowingPage = (accountname) => {
+    navigate(`/profile/${accountname}/following`);
   };
 
   return (
     <S.UserInfoContainer>
       <S.FollowInfoContainer>
-        <S.FollowInfo>
+        <S.FollowInfo onClick={() => goToFollowerPage(accountName)}>
           <S.FollowCount>{followerCount}</S.FollowCount>
           <S.FollowType>followers</S.FollowType>
         </S.FollowInfo>
@@ -32,7 +43,7 @@ function UserInfo({
           alt="프로필 이미지"
           onError={handleErrorImage}
         />
-        <S.FollowInfo>
+        <S.FollowInfo onClick={() => goToFollowingPage(accountName)}>
           <S.FollowCount>{followingCount}</S.FollowCount>
           <S.FollowType>followings</S.FollowType>
         </S.FollowInfo>

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -1,5 +1,6 @@
-import React, { useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 
 import * as S from './index.styles';
 import { MEDIUM_BUTTON } from '../../../constants/buttonStyle';
@@ -7,6 +8,8 @@ import chatIcon from '../../../assets/icon/icon-message-circle-1.png';
 import shareIcon from '../../../assets/icon/icon-share.png';
 import basicProfileImage from '../../../assets/basic-profile.png';
 import Snackbar from '../../Modal/SnackBar';
+
+import { deleteFollow, postFollow } from '../../../api/follow';
 
 function UserInfo({
   followerCount,
@@ -21,6 +24,17 @@ function UserInfo({
   const [isSnackBarOpen, setIsSnackBarOpen] = useState(false);
   const [snackBarMessage, setSnackBarMessage] = useState('');
   const navigate = useNavigate();
+
+  const followUser = useMutation(() => postFollow(accountName));
+  const unFollowUser = useMutation(() => deleteFollow(accountName));
+
+  const handleFollowUser = () => {
+    if (isFollow) {
+      unFollowUser.mutate();
+    } else {
+      followUser.mutate();
+    }
+  };
 
   const handleErrorImage = (e) => {
     e.target.src = basicProfileImage;
@@ -106,6 +120,7 @@ function UserInfo({
             <S.FollowButton
               text={isFollow ? '언팔로우' : '팔로우'}
               buttonStyle={MEDIUM_BUTTON}
+              onClick={handleFollowUser}
               cancel={isFollow && true}
             />
             <S.IconButton onClick={copyProfileAddress}>

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useMutation } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 import * as S from './index.styles';
@@ -10,26 +10,22 @@ import basicProfileImage from '../../../assets/basic-profile.png';
 import Snackbar from '../../Modal/SnackBar';
 
 import { deleteFollow, postFollow } from '../../../api/follow';
+import getProfileInfo from '../../../api/profile';
 
-function UserInfo({
-  followerCount,
-  profileImage,
-  followingCount,
-  userName,
-  accountName,
-  intro,
-  isFollow,
-  isMyPage,
-}) {
+function UserInfo({ isMyPage, accountName }) {
   const [isSnackBarOpen, setIsSnackBarOpen] = useState(false);
   const [snackBarMessage, setSnackBarMessage] = useState('');
   const navigate = useNavigate();
+
+  const { data, isLoading, isError } = useQuery('profileInfo', () =>
+    getProfileInfo(accountName)
+  );
 
   const followUser = useMutation(() => postFollow(accountName));
   const unFollowUser = useMutation(() => deleteFollow(accountName));
 
   const handleFollowUser = () => {
-    if (isFollow) {
+    if (data.profile.isfollow) {
       unFollowUser.mutate();
     } else {
       followUser.mutate();
@@ -77,60 +73,64 @@ function UserInfo({
   };
 
   return (
-    <S.UserInfoContainer>
-      <S.FollowInfoContainer>
-        <S.FollowInfo onClick={() => goToFollowerPage(accountName)}>
-          <S.FollowCount>{followerCount}</S.FollowCount>
-          <S.FollowType>followers</S.FollowType>
-        </S.FollowInfo>
-        <S.ProfileImage
-          src={profileImage}
-          alt="프로필 이미지"
-          onError={handleErrorImage}
-        />
-        <S.FollowInfo onClick={() => goToFollowingPage(accountName)}>
-          <S.FollowCount>{followingCount}</S.FollowCount>
-          <S.FollowType>followings</S.FollowType>
-        </S.FollowInfo>
-      </S.FollowInfoContainer>
-      <S.UserName>{userName}</S.UserName>
-      <S.AccountName>@{accountName}</S.AccountName>
-      <S.Intro>{intro}</S.Intro>
-      <S.ButtonContainer>
-        {isMyPage ? (
-          <>
-            <S.FollowButton
-              text="프로필 수정"
-              buttonStyle={MEDIUM_BUTTON}
-              onClick={goToProfileEditPage}
-              cancel
+    <>
+      {!isLoading && (
+        <S.UserInfoContainer>
+          <S.FollowInfoContainer>
+            <S.FollowInfo onClick={() => goToFollowerPage(accountName)}>
+              <S.FollowCount>{data.profile.followerCount}</S.FollowCount>
+              <S.FollowType>followers</S.FollowType>
+            </S.FollowInfo>
+            <S.ProfileImage
+              src={data.profile.image}
+              alt="프로필 이미지"
+              onError={handleErrorImage}
             />
-            <S.FollowButton
-              text="myPick 등록"
-              buttonStyle={MEDIUM_BUTTON}
-              onClick={goToMyPicksPage}
-              cancel
-            />
-          </>
-        ) : (
-          <>
-            <S.IconButton onClick={goToChatPage}>
-              <img src={chatIcon} alt="채팅 아이콘" />
-            </S.IconButton>
-            <S.FollowButton
-              text={isFollow ? '언팔로우' : '팔로우'}
-              buttonStyle={MEDIUM_BUTTON}
-              onClick={handleFollowUser}
-              cancel={isFollow && true}
-            />
-            <S.IconButton onClick={copyProfileAddress}>
-              <img src={shareIcon} alt="공유 아이콘" />
-            </S.IconButton>
-          </>
-        )}
-      </S.ButtonContainer>
-      {isSnackBarOpen && <Snackbar content={snackBarMessage} />}
-    </S.UserInfoContainer>
+            <S.FollowInfo onClick={() => goToFollowingPage(accountName)}>
+              <S.FollowCount>{data.profile.followingCount}</S.FollowCount>
+              <S.FollowType>followings</S.FollowType>
+            </S.FollowInfo>
+          </S.FollowInfoContainer>
+          <S.UserName>{data.profile.username}</S.UserName>
+          <S.AccountName>@{data.profile.accountname}</S.AccountName>
+          <S.Intro>{data.profile.intro}</S.Intro>
+          <S.ButtonContainer>
+            {isMyPage ? (
+              <>
+                <S.FollowButton
+                  text="프로필 수정"
+                  buttonStyle={MEDIUM_BUTTON}
+                  onClick={goToProfileEditPage}
+                  cancel
+                />
+                <S.FollowButton
+                  text="myPick 등록"
+                  buttonStyle={MEDIUM_BUTTON}
+                  onClick={goToMyPicksPage}
+                  cancel
+                />
+              </>
+            ) : (
+              <>
+                <S.IconButton onClick={goToChatPage}>
+                  <img src={chatIcon} alt="채팅 아이콘" />
+                </S.IconButton>
+                <S.FollowButton
+                  text={data.profile.isfollow ? '언팔로우' : '팔로우'}
+                  buttonStyle={MEDIUM_BUTTON}
+                  onClick={handleFollowUser}
+                  cancel={data.profile.isfollow && true}
+                />
+                <S.IconButton onClick={copyProfileAddress}>
+                  <img src={shareIcon} alt="공유 아이콘" />
+                </S.IconButton>
+              </>
+            )}
+          </S.ButtonContainer>
+          {isSnackBarOpen && <Snackbar content={snackBarMessage} />}
+        </S.UserInfoContainer>
+      )}
+    </>
   );
 }
 

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -12,17 +12,18 @@ import PostList from '../../components/Post/PostList';
 import hookieImage from '../../assets/Hookie.png';
 import * as S from './index.styles';
 
-import { getFollowPost, getMyPost } from '../../api/post';
+import { getAccountPost, getFollowPost } from '../../api/post';
 
 function Home() {
   const [allPost, setAllPost] = useState([]);
   const navigate = useNavigate();
+  const myAccountName = JSON.parse(localStorage.getItem('accountName'));
 
   const {
     data: myPost,
     isLoading: isMyPostLoading,
     isError: isMyPostError,
-  } = useQuery('myPostList', getMyPost);
+  } = useQuery('myPostList', () => getAccountPost(myAccountName));
 
   const {
     data: followPost,

--- a/src/pages/Post/PostEdit/index.jsx
+++ b/src/pages/Post/PostEdit/index.jsx
@@ -32,7 +32,7 @@ function PostEdit() {
 
     try {
       const response = editMyPost(imageSrcList, contents, postId);
-      return response.then(navigate(`/profile`));
+      return response.then(navigate(-1));
     } catch (error) {
       return error;
     }

--- a/src/pages/Post/PostUpload/index.jsx
+++ b/src/pages/Post/PostUpload/index.jsx
@@ -28,7 +28,7 @@ function PostUpload() {
 
     try {
       const response = createMyPost(imageSrcList, contents);
-      return response.then(navigate(`/profile`));
+      return response.then(navigate(-1));
     } catch (error) {
       return error;
     }

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -21,7 +21,7 @@ function Follower() {
   const navigate = useNavigate();
 
   const handleToProfile = () => {
-    navigate('/profile');
+    navigate(-1);
   };
 
   const [followerData, setFollowerData] = useState([]);

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
 import * as S from './index.styles';
@@ -19,8 +19,13 @@ import postAlbumOffIcon from '../../assets/icon/icon-post-album-off.png';
 
 import getProfileInfo from '../../api/profile';
 import { getMyPost } from '../../api/post';
+import BottomSheet from '../../components/Modal/BottomSheet';
+import BottomSheetContent from '../../components/Modal/BottomSheet/BottomSheetContent';
 
 function Profile() {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const navigate = useNavigate();
   const param = useParams();
   const isMyPage = param.id === JSON.parse(localStorage.getItem('accountName'));
 
@@ -38,14 +43,23 @@ function Profile() {
     console.log(data.profile);
   }
 
+  const goBackPage = () => {
+    navigate(-1);
+  };
+
+  const handleBottomSheetOpen = (e) => {
+    e.stopPropagation();
+    setIsBottomSheetOpen(!isBottomSheetOpen);
+  };
+
   return (
     <>
       <BaseHeader
         leftIcon={leftArrowIcon}
-        leftClick={() => {}}
+        leftClick={goBackPage}
         rightIcon={verticalIcon}
         rightAlt="프로필 설정"
-        rightClick={() => {}}
+        rightClick={handleBottomSheetOpen}
       />
       <S.Container>
         {!isLoading && (
@@ -82,6 +96,12 @@ function Profile() {
       </S.Container>
 
       <Navigation />
+      {isBottomSheetOpen && (
+        <BottomSheet handleClose={handleBottomSheetOpen}>
+          <BottomSheetContent text="다크모드" />
+          <BottomSheetContent text="로그아웃" />
+        </BottomSheet>
+      )}
     </>
   );
 }

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -8,19 +8,11 @@ import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
 import UserInfo from '../../components/Profile/UserInfo';
-import PostList from '../../components/Post/PostList';
-import { LARGE_BUTTON } from '../../constants/buttonStyle';
-import logoGrey from '../../assets/logo_grey.png';
-import Button from '../../components/common/Button';
-import postListOnIcon from '../../assets/icon/icon-post-list-on.png';
-import postListOffIcon from '../../assets/icon/icon-post-list-off.png';
-import postAlbumOnIcon from '../../assets/icon/icon-post-album-on.png';
-import postAlbumOffIcon from '../../assets/icon/icon-post-album-off.png';
 
 import getProfileInfo from '../../api/profile';
-import { getAccountPost } from '../../api/post';
 import BottomSheet from '../../components/Modal/BottomSheet';
 import BottomSheetContent from '../../components/Modal/BottomSheet/BottomSheetContent';
+import ProfilePost from '../../components/Profile/ProfilePost';
 
 function Profile() {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
@@ -33,12 +25,6 @@ function Profile() {
   const { data, isLoading, isError } = useQuery('profileInfo', () =>
     getProfileInfo(param.accountname)
   );
-
-  const {
-    data: myPost,
-    isLoading: isMyPostLoading,
-    isError: isMyPostError,
-  } = useQuery('myPostList', () => getAccountPost(param.accountname));
 
   const goBackPage = () => {
     navigate(-1);
@@ -71,25 +57,7 @@ function Profile() {
             isMyPage={isMyPage}
           />
         )}
-        <S.PostContainer>
-          <S.PostTypeContainer>
-            <S.PostTypeButton>
-              <img src={postListOnIcon} alt="리스트형 포스트" />
-            </S.PostTypeButton>
-            <S.PostTypeButton>
-              <img src={postAlbumOnIcon} alt="앨범형 포스트" />
-            </S.PostTypeButton>
-          </S.PostTypeContainer>
-          {myPost?.post.length > 0 ? (
-            <PostList postData={myPost.post} myPage />
-          ) : (
-            <S.EmptyContainer>
-              <S.EmptyImage src={logoGrey} alt="로고 이미지" />
-              <S.EmptyContent>게시글이 없습니다 !</S.EmptyContent>
-              <Button text="게시물 작성하기" buttonStyle={LARGE_BUTTON} />
-            </S.EmptyContainer>
-          )}
-        </S.PostContainer>
+        <ProfilePost accountName={param.accountname} />
       </S.Container>
 
       <Navigation />

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -27,10 +27,11 @@ function Profile() {
 
   const navigate = useNavigate();
   const param = useParams();
-  const isMyPage = param.id === JSON.parse(localStorage.getItem('accountName'));
+  const isMyPage =
+    param.accountname === JSON.parse(localStorage.getItem('accountName'));
 
   const { data, isLoading, isError } = useQuery('profileInfo', () =>
-    getProfileInfo(param.id)
+    getProfileInfo(param.accountname)
   );
 
   const {

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -18,7 +18,7 @@ import postAlbumOnIcon from '../../assets/icon/icon-post-album-on.png';
 import postAlbumOffIcon from '../../assets/icon/icon-post-album-off.png';
 
 import getProfileInfo from '../../api/profile';
-import { getMyPost } from '../../api/post';
+import { getAccountPost } from '../../api/post';
 import BottomSheet from '../../components/Modal/BottomSheet';
 import BottomSheetContent from '../../components/Modal/BottomSheet/BottomSheetContent';
 
@@ -38,7 +38,7 @@ function Profile() {
     data: myPost,
     isLoading: isMyPostLoading,
     isError: isMyPostError,
-  } = useQuery('myPostList', getMyPost);
+  } = useQuery('myPostList', () => getAccountPost(param.accountname));
 
   const goBackPage = () => {
     navigate(-1);

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
 
 import * as S from './index.styles';
 import BaseHeader from '../../components/common/BaseHeader';
@@ -8,11 +7,9 @@ import Navigation from '../../components/common/Navigation';
 import leftArrowIcon from '../../assets/icon/icon-arrow-left.png';
 import verticalIcon from '../../assets/icon/s-icon-more-vertical.png';
 import UserInfo from '../../components/Profile/UserInfo';
-
-import getProfileInfo from '../../api/profile';
+import ProfilePost from '../../components/Profile/ProfilePost';
 import BottomSheet from '../../components/Modal/BottomSheet';
 import BottomSheetContent from '../../components/Modal/BottomSheet/BottomSheetContent';
-import ProfilePost from '../../components/Profile/ProfilePost';
 
 function Profile() {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
@@ -21,10 +18,6 @@ function Profile() {
   const param = useParams();
   const isMyPage =
     param.accountname === JSON.parse(localStorage.getItem('accountName'));
-
-  const { data, isLoading, isError } = useQuery('profileInfo', () =>
-    getProfileInfo(param.accountname)
-  );
 
   const goBackPage = () => {
     navigate(-1);
@@ -45,18 +38,7 @@ function Profile() {
         rightClick={handleBottomSheetOpen}
       />
       <S.Container>
-        {!isLoading && (
-          <UserInfo
-            followerCount={data.profile.followerCount}
-            followingCount={data.profile.followingCount}
-            profileImage={data.profile.image}
-            userName={data.profile.username}
-            accountName={data.profile.accountname}
-            intro={data.profile.intro}
-            isFollow={data.profile.isfollow}
-            isMyPage={isMyPage}
-          />
-        )}
+        <UserInfo accountName={param.accountname} isMyPage={isMyPage} />
         <ProfilePost accountName={param.accountname} />
       </S.Container>
 

--- a/src/pages/Profile/index.jsx
+++ b/src/pages/Profile/index.jsx
@@ -40,10 +40,6 @@ function Profile() {
     isError: isMyPostError,
   } = useQuery('myPostList', getMyPost);
 
-  if (!isLoading) {
-    console.log(data.profile);
-  }
-
   const goBackPage = () => {
     navigate(-1);
   };


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 각종 버튼 클릭 시 해당 페이지로 이동되도록 구현, 클립 복사 기능, 팔로우, 언팔로우 기능, 리스트형 앨범형 표시 기능 추가
- [x] 마크업 & 스타일 : 앨범형 포스트 마크업 추가
- [x] 리팩토링 : 라우터 주소 수정


## 💬 전달사항
- 앨범형 아이템 세로 길이를 고정했기 때문에 화면이 커질 경우 대응 불가능 (해결 못했습니다..)
- 다크모드, 로그아웃, 프로필 수정, 팔로잉 목록 페이지 작업 필요
- chat 페이지에서 뒤로가기시 홈으로 고정된 것 수정 필요


## 💬 스크린샷
나의 프로필 페이지
![Dec-25-2022 18-50-50](https://user-images.githubusercontent.com/71367408/209463510-d6c1924e-a57f-4f90-9d1a-ca52b6d4e6e9.gif)


타인의 프로필 페이지
![Dec-25-2022 18-50-42](https://user-images.githubusercontent.com/71367408/209463507-96c68d2b-0cda-4573-a865-41261a1aa0b8.gif)


## 💬 Issue Number
close : #94 
