### PR TITLE
프로필 세팅 페이지 UI, 기능 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "react/no-unknown-property": "off",
     "react/jsx-props-no-spreading": "off",
     "no-alert": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "import/prefer-default-export": "off"
   }
 }

--- a/src/atoms/profileInfo.js
+++ b/src/atoms/profileInfo.js
@@ -1,0 +1,31 @@
+import { atom } from 'recoil';
+
+export const profileUserName = atom({
+  key: 'profileUserName',
+  default: '',
+});
+
+export const profileAccountName = atom({
+  key: 'profileAccountName',
+  default: '',
+});
+
+export const profileImage = atom({
+  key: 'profileImage',
+  default: '',
+});
+
+export const profileIntro = atom({
+  key: 'profileIntro',
+  default: '',
+});
+
+export const profileAccountNameValid = atom({
+  key: 'profileAccountNameValid',
+  default: false,
+});
+
+export const profileAccountNameWarningMessage = atom({
+  key: 'profileAccountNameWarningMessage',
+  default: '',
+});

--- a/src/atoms/profileInfo.js
+++ b/src/atoms/profileInfo.js
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
 
 export const profileUserName = atom({
   key: 'profileUserName',
@@ -20,12 +20,46 @@ export const profileIntro = atom({
   default: '',
 });
 
-export const profileAccountNameValid = atom({
-  key: 'profileAccountNameValid',
-  default: false,
+export const isSubscribedAccountState = atom({
+  key: 'isSubscribedAccountState',
+  default: {
+    accountNameValid: true,
+    validWarningMessage: '',
+  },
 });
 
-export const profileAccountNameWarningMessage = atom({
-  key: 'profileAccountNameWarningMessage',
-  default: '',
+export const profileInputValid = selector({
+  key: 'profileInputValid',
+  get: ({ get }) => {
+    const userName = get(profileUserName);
+    const accountName = get(profileAccountName);
+    let accountNameValid;
+    let userNameValid;
+    let accountNameWarningMessage;
+    let userNameWarningMessage;
+
+    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
+
+    if (ID_REGEX.test(accountName)) {
+      accountNameValid = true;
+    } else {
+      accountNameValid = false;
+      accountNameWarningMessage =
+        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.';
+    }
+
+    if (userName.length < 2 || userName.length > 10) {
+      userNameValid = false;
+      userNameWarningMessage = '* 2~10자 이내로 입력해주세요';
+    } else {
+      userNameValid = true;
+    }
+
+    return {
+      accountNameValid,
+      userNameValid,
+      accountNameWarningMessage,
+      userNameWarningMessage,
+    };
+  },
 });

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -73,7 +73,10 @@ function AuthInputForm({
     if (location.pathname === '/login') {
       handleLoginState(e);
     }
-    if (location.pathname === '/signup/profile') {
+    if (
+      location.pathname === '/signup/profile' ||
+      location.pathname === '/profile/edit'
+    ) {
       handleProfileState(e);
     }
   };

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -58,9 +58,9 @@ function AuthInputForm({
   handleSignUpState,
   handleLoginState,
   handleProfileState,
+  inputValue,
   signUpValid,
   profileValid,
-  inputValue,
   isCorrect,
   inputRef,
 }) {
@@ -88,6 +88,7 @@ function AuthInputForm({
         id={id}
         {...inputProps}
         ref={inputRef}
+        value={inputValue}
         inputValue={inputValue}
         signUpValid={signUpValid}
         profileValid={profileValid}

--- a/src/components/Profile/ProfileInfoForm/index.jsx
+++ b/src/components/Profile/ProfileInfoForm/index.jsx
@@ -63,7 +63,7 @@ function ProfileInfoForm({ edit, savedData }) {
 
   return (
     <>
-      <ProfileImageInput edit savedImage={savedData.profileImage} />
+      <ProfileImageInput savedImage={savedData && savedData.profileImage} />
       <S.FormContainer>
         <AuthInputForm
           id="id"

--- a/src/components/Profile/ProfileInfoForm/index.jsx
+++ b/src/components/Profile/ProfileInfoForm/index.jsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import * as S from './index.styles';
+import ProfileImageInput from '../../ProfileImageInput';
+import AuthInputForm from '../../AuthInputForm';
+import {
+  profileAccountName,
+  profileAccountNameValid,
+  profileAccountNameWarningMessage,
+  profileIntro,
+  profileUserName,
+} from '../../../atoms/profileInfo';
+
+function ProfileInfoForm() {
+  const textareaRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const [accountName, setAccountName] = useRecoilState(profileAccountName);
+  const [userName, setUserName] = useRecoilState(profileUserName);
+  const [intro, setIntro] = useRecoilState(profileIntro);
+
+  const [accountNameValid, setAccountNameValid] = useRecoilState(
+    profileAccountNameValid
+  );
+  const [userNameValid, setUserNameValid] = useState(false);
+
+  const [accountNameWarningMsg, setAccountNameWarningMsg] = useRecoilState(
+    profileAccountNameWarningMessage
+  );
+  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
+
+  const [buttonNotAllow, setButtonNotAllow] = useState(true);
+
+  const handleAccountName = (e) => {
+    setAccountName(e.target.value);
+  };
+  const handleUserName = (e) => {
+    setUserName(e.target.value);
+  };
+  const handleIntro = (e) => {
+    setIntro(e.target.value);
+  };
+
+  // 인풋창 입력할 때마다 유효성 검사
+  useEffect(() => {
+    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
+
+    if (ID_REGEX.test(accountName)) {
+      setAccountNameValid(true);
+    } else {
+      setAccountNameValid(false);
+      setAccountNameWarningMsg(
+        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
+      );
+    }
+
+    if (userName.length < 2 || userName.length > 10) {
+      setUserNameValid(false);
+      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
+    } else {
+      setUserNameValid(true);
+    }
+  }, [accountName, userName]);
+
+  // 아이디와 이름 유효성 통과 시 버튼 활성화
+  useEffect(() => {
+    if (accountNameValid && userNameValid) {
+      return setButtonNotAllow(false);
+    }
+    return setButtonNotAllow(true);
+  }, [accountName, userName]);
+
+  // 아이디 인풋창 자동 포커스
+  useEffect(() => {
+    console.log(inputRef);
+  }, []);
+
+  // 소개 textarea 높이
+  const handleResizeHeight = () => {
+    textareaRef.current.style.height = `38px`;
+    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+  };
+
+  return (
+    <>
+      <ProfileImageInput />
+      <S.FormContainer>
+        <AuthInputForm
+          id="id"
+          label="사용자 ID"
+          inputProps={{
+            type: 'text',
+            placeholder: '아이디를 입력해주세요',
+          }}
+          handleProfileState={handleAccountName}
+          inputValue={accountName}
+          profileValid={accountNameValid}
+          warningMsg={accountNameWarningMsg}
+          inputRef={inputRef}
+        />
+        <AuthInputForm
+          id="name"
+          label="사용자 이름"
+          inputProps={{
+            type: 'text',
+            placeholder: '이름을 입력해주세요',
+          }}
+          handleProfileState={handleUserName}
+          inputValue={userName}
+          profileValid={userNameValid}
+          warningMsg={userNameWarningMsg}
+        />
+        <S.IntroFormContainer>
+          <S.Label htmlFor="intro">소개</S.Label>
+          <S.IntroContent
+            id="intro"
+            name="intro"
+            placeholder="소개글을 입력해주세요"
+            rows={1}
+            cols={20}
+            maxLength={100}
+            wrap="hard"
+            ref={textareaRef}
+            onInput={handleResizeHeight}
+            value={intro}
+            onChange={handleIntro}
+          />
+        </S.IntroFormContainer>
+      </S.FormContainer>
+    </>
+  );
+}
+
+export default ProfileInfoForm;

--- a/src/components/Profile/ProfileInfoForm/index.jsx
+++ b/src/components/Profile/ProfileInfoForm/index.jsx
@@ -12,7 +12,7 @@ import {
   profileUserName,
 } from '../../../atoms/profileInfo';
 
-function ProfileInfoForm() {
+function ProfileInfoForm({ edit, savedData }) {
   const textareaRef = useRef(null);
   const inputRef = useRef(null);
 
@@ -27,6 +27,18 @@ function ProfileInfoForm() {
     accountNameWarningMessage,
     userNameWarningMessage,
   } = useRecoilValue(profileInputValid);
+
+  useEffect(() => {
+    if (edit) {
+      setAccountName(savedData.accountName);
+      setUserName(savedData.userName);
+      setIntro(savedData.intro);
+    } else {
+      setAccountName('');
+      setUserName('');
+      setIntro('');
+    }
+  }, []);
 
   const handleAccountName = (e) => {
     setAccountName(e.target.value);
@@ -51,7 +63,7 @@ function ProfileInfoForm() {
 
   return (
     <>
-      <ProfileImageInput />
+      <ProfileImageInput edit savedImage={savedData.profileImage} />
       <S.FormContainer>
         <AuthInputForm
           id="id"

--- a/src/components/Profile/ProfileInfoForm/index.jsx
+++ b/src/components/Profile/ProfileInfoForm/index.jsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useEffect, useRef } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import * as S from './index.styles';
 import ProfileImageInput from '../../ProfileImageInput';
 import AuthInputForm from '../../AuthInputForm';
 import {
+  isSubscribedAccountState,
   profileAccountName,
-  profileAccountNameValid,
-  profileAccountNameWarningMessage,
+  profileInputValid,
   profileIntro,
   profileUserName,
 } from '../../../atoms/profileInfo';
@@ -20,17 +20,13 @@ function ProfileInfoForm() {
   const [userName, setUserName] = useRecoilState(profileUserName);
   const [intro, setIntro] = useRecoilState(profileIntro);
 
-  const [accountNameValid, setAccountNameValid] = useRecoilState(
-    profileAccountNameValid
-  );
-  const [userNameValid, setUserNameValid] = useState(false);
-
-  const [accountNameWarningMsg, setAccountNameWarningMsg] = useRecoilState(
-    profileAccountNameWarningMessage
-  );
-  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
-
-  const [buttonNotAllow, setButtonNotAllow] = useState(true);
+  const isSubscribedAccount = useRecoilValue(isSubscribedAccountState);
+  const {
+    accountNameValid,
+    userNameValid,
+    accountNameWarningMessage,
+    userNameWarningMessage,
+  } = useRecoilValue(profileInputValid);
 
   const handleAccountName = (e) => {
     setAccountName(e.target.value);
@@ -42,38 +38,9 @@ function ProfileInfoForm() {
     setIntro(e.target.value);
   };
 
-  // 인풋창 입력할 때마다 유효성 검사
-  useEffect(() => {
-    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
-
-    if (ID_REGEX.test(accountName)) {
-      setAccountNameValid(true);
-    } else {
-      setAccountNameValid(false);
-      setAccountNameWarningMsg(
-        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
-      );
-    }
-
-    if (userName.length < 2 || userName.length > 10) {
-      setUserNameValid(false);
-      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
-    } else {
-      setUserNameValid(true);
-    }
-  }, [accountName, userName]);
-
-  // 아이디와 이름 유효성 통과 시 버튼 활성화
-  useEffect(() => {
-    if (accountNameValid && userNameValid) {
-      return setButtonNotAllow(false);
-    }
-    return setButtonNotAllow(true);
-  }, [accountName, userName]);
-
   // 아이디 인풋창 자동 포커스
   useEffect(() => {
-    console.log(inputRef);
+    inputRef.current.focus();
   }, []);
 
   // 소개 textarea 높이
@@ -95,8 +62,14 @@ function ProfileInfoForm() {
           }}
           handleProfileState={handleAccountName}
           inputValue={accountName}
-          profileValid={accountNameValid}
-          warningMsg={accountNameWarningMsg}
+          profileValid={
+            isSubscribedAccount.accountNameValid && accountNameValid
+          }
+          warningMsg={
+            isSubscribedAccount.accountNameValid
+              ? accountNameWarningMessage
+              : isSubscribedAccount.validWarningMessage
+          }
           inputRef={inputRef}
         />
         <AuthInputForm
@@ -109,7 +82,7 @@ function ProfileInfoForm() {
           handleProfileState={handleUserName}
           inputValue={userName}
           profileValid={userNameValid}
-          warningMsg={userNameWarningMsg}
+          warningMsg={userNameWarningMessage}
         />
         <S.IntroFormContainer>
           <S.Label htmlFor="intro">소개</S.Label>

--- a/src/components/Profile/ProfileInfoForm/index.styles.js
+++ b/src/components/Profile/ProfileInfoForm/index.styles.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  width: 100%;
+`;
+
+export const IntroFormContainer = styled.div``;
+
+export const Label = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+`;
+
+export const IntroContent = styled.textarea`
+  display: block;
+  width: 100%;
+  margin-top: 0.7rem;
+  padding: 1.2rem 1.5rem;
+  word-wrap: break-word;
+  font-family: Arial;
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.DARK_GRAY};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  }
+`;

--- a/src/components/Profile/ProfileInfoForm/index.styles.js
+++ b/src/components/Profile/ProfileInfoForm/index.styles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const FormContainer = styled.form`
   display: flex;
@@ -28,4 +28,10 @@ export const IntroContent = styled.textarea`
   &::placeholder {
     color: ${({ theme }) => theme.color.LIGHT_GRAY};
   }
+
+  ${({ value }) =>
+    value.length > 0 &&
+    css`
+      border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
+    `}
 `;

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -45,7 +45,14 @@ function UserInfo({ isMyPage, accountName }) {
   };
 
   const goToProfileEditPage = () => {
-    navigate(`/profile/edit`);
+    navigate(`/profile/edit`, {
+      state: {
+        userName: data.profile.username,
+        accountName: data.profile.accountname,
+        intro: data.profile.intro,
+        profileImage: data.profile.image,
+      },
+    });
   };
 
   const goToMyPicksPage = () => {

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,11 +1,14 @@
 import React, { useCallback, useRef, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import axios from 'axios';
 
 import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
+import { profileImage } from '../../atoms/profileInfo';
 
-function ProfileImageInput({ handleProfileImage }) {
-  const [profileImage, setProfileImage] = useState(basicProfileImage);
+function ProfileImageInput() {
+  const [profileImages, setProfileImages] = useState(basicProfileImage);
+  const setImage = useSetRecoilState(profileImage);
   const imageInput = useRef(null);
 
   const fetchImage = async (image) => {
@@ -19,8 +22,8 @@ function ProfileImageInput({ handleProfileImage }) {
         formData
       );
 
-      handleProfileImage(res.data.filename);
-      setProfileImage(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
+      setProfileImages(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
+      setImage(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
 
       return res.data.filename;
     } catch (error) {
@@ -30,11 +33,12 @@ function ProfileImageInput({ handleProfileImage }) {
 
   const handleImageChange = useCallback((e) => {
     const currentImage = e.target.files[0];
+    console.log(currentImage);
 
     if (currentImage) {
       fetchImage(currentImage);
     } else {
-      setProfileImage(basicProfileImage);
+      setProfileImages(basicProfileImage);
       fetchImage(basicProfileImage);
     }
   }, []);
@@ -45,8 +49,7 @@ function ProfileImageInput({ handleProfileImage }) {
         imageInput.current.click();
       }}
     >
-      {/* {console.log(profileImage)} */}
-      <S.ImageInput src={profileImage} />
+      <S.ImageInput src={profileImages} />
       <input
         type="file"
         accept="image/jpg, image/jpeg, image/png, image/gif, image/bmp, image/tif, image/heic"

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -6,15 +6,18 @@ import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
 import { profileImage } from '../../atoms/profileInfo';
 
-function ProfileImageInput({ edit, savedImage }) {
-  const [profileImages, setProfileImages] = useState(basicProfileImage);
+function ProfileImageInput({ savedImage }) {
+  const [profileImages, setProfileImages] = useState('');
   const setImage = useSetRecoilState(profileImage);
   const imageInput = useRef(null);
 
   useEffect(() => {
-    if (edit) {
+    console.log(savedImage);
+    if (savedImage) {
       setProfileImages(savedImage);
       setImage(savedImage);
+    } else {
+      setProfileImages(basicProfileImage);
     }
   }, []);
 

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import axios from 'axios';
 
@@ -6,10 +6,17 @@ import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
 import { profileImage } from '../../atoms/profileInfo';
 
-function ProfileImageInput() {
+function ProfileImageInput({ edit, savedImage }) {
   const [profileImages, setProfileImages] = useState(basicProfileImage);
   const setImage = useSetRecoilState(profileImage);
   const imageInput = useRef(null);
+
+  useEffect(() => {
+    if (edit) {
+      setProfileImages(savedImage);
+      setImage(savedImage);
+    }
+  }, []);
 
   const fetchImage = async (image) => {
     const formData = new FormData();

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import axios from 'axios';
 
 import * as S from './index.style';
@@ -20,6 +20,7 @@ function ProfileImageInput({ handleProfileImage }) {
       );
 
       handleProfileImage(res.data.filename);
+      setProfileImage(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
 
       return res.data.filename;
     } catch (error) {
@@ -36,17 +37,6 @@ function ProfileImageInput({ handleProfileImage }) {
       setProfileImage(basicProfileImage);
       fetchImage(basicProfileImage);
     }
-
-    // 업로드 이미지 preview
-    const reader = new FileReader();
-
-    reader.onload = () => {
-      if (reader.readyState === 2) {
-        setProfileImage(reader.result);
-      }
-    };
-
-    reader.readAsDataURL(currentImage);
   }, []);
 
   return (
@@ -55,6 +45,7 @@ function ProfileImageInput({ handleProfileImage }) {
         imageInput.current.click();
       }}
     >
+      {/* {console.log(profileImage)} */}
       <S.ImageInput src={profileImage} />
       <input
         type="file"

--- a/src/components/common/ConfirmHeader/index.jsx
+++ b/src/components/common/ConfirmHeader/index.jsx
@@ -25,6 +25,11 @@ const SButton = styled.button`
   background-color: inherit;
   cursor: pointer;
   width: 2.2rem;
+
+  &:disabled {
+    cursor: default;
+    background-color: ${({ theme }) => theme.color.DISABLED_BLUE};
+  }
 `;
 
 function ConfirmHeader({

--- a/src/components/common/ConfirmHeader/index.jsx
+++ b/src/components/common/ConfirmHeader/index.jsx
@@ -27,7 +27,12 @@ const SButton = styled.button`
   width: 2.2rem;
 `;
 
-function ConfirmHeader({ leftClick, rightClick, rightButtonText = '저장' }) {
+function ConfirmHeader({
+  leftClick,
+  rightClick,
+  rightButtonText = '저장',
+  buttonNotAllow,
+}) {
   return (
     <SContainer>
       <SButton onClick={leftClick}>
@@ -37,6 +42,7 @@ function ConfirmHeader({ leftClick, rightClick, rightButtonText = '저장' }) {
         onClick={rightClick}
         text={rightButtonText}
         buttonStyle={SMALL_BUTTON}
+        disabled={buttonNotAllow}
       />
     </SContainer>
   );

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -1,85 +1,36 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
 import * as S from './index.style';
 import Title from '../../../components/Title';
-import ProfileImageInput from '../../../components/ProfileImageInput';
-import AuthInputForm from '../../../components/AuthInputForm';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 import authAxios from '../../../api/authAxios';
+import {
+  profileAccountName,
+  profileAccountNameValid,
+  profileAccountNameWarningMessage,
+  profileImage,
+  profileIntro,
+  profileUserName,
+} from '../../../atoms/profileInfo';
+import ProfileInfoForm from '../../../components/Profile/ProfileInfoForm';
 
 function ProfileSetting() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const textareaRef = useRef(null);
-  const inputRef = useRef(null);
 
-  const [accountName, setAccountName] = useState('');
-  const [userName, setUserName] = useState('');
-  const [intro, setIntro] = useState('');
-  const [image, setImage] = useState('');
+  const userName = useRecoilValue(profileUserName);
+  const accountName = useRecoilValue(profileAccountName);
+  const image = useRecoilValue(profileImage);
+  const intro = useRecoilValue(profileIntro);
 
-  const [accountNameValid, setAccountNameValid] = useState(false);
-  const [userNameValid, setUserNameValid] = useState(false);
-
-  const [accountNameWarningMsg, setAccountNameWarningMsg] = useState('');
-  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
+  const setAccountNameValid = useSetRecoilState(profileAccountNameValid);
+  const setAccountNameWarningMsg = useSetRecoilState(
+    profileAccountNameWarningMessage
+  );
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
-
-  const handleAccountName = (e) => {
-    setAccountName(e.target.value);
-  };
-  const handleUserName = (e) => {
-    setUserName(e.target.value);
-  };
-  const handleIntro = (e) => {
-    setIntro(e.target.value);
-  };
-
-  // 자식 컴포넌트에서 이미지 src 가져오기
-  const handleProfileImage = (targetImage) => {
-    setImage(targetImage);
-  };
-
-  // 인풋창 입력할 때마다 유효성 검사
-  useEffect(() => {
-    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
-
-    if (ID_REGEX.test(accountName)) {
-      setAccountNameValid(true);
-    } else {
-      setAccountNameValid(false);
-      setAccountNameWarningMsg(
-        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
-      );
-    }
-
-    if (userName.length < 2 || userName.length > 10) {
-      setUserNameValid(false);
-      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
-    } else {
-      setUserNameValid(true);
-    }
-  }, [accountName, userName]);
-
-  // 아이디와 이름 유효성 통과 시 버튼 활성화
-  useEffect(() => {
-    if (accountNameValid && userNameValid) {
-      return setButtonNotAllow(false);
-    }
-    return setButtonNotAllow(true);
-  }, [accountName, userName]);
-
-  // 아이디 인풋창 자동 포커스
-  useEffect(() => {
-    inputRef.current.focus();
-  }, []);
-
-  // 소개 textarea 높이
-  const handleResizeHeight = () => {
-    textareaRef.current.style.height = `38px`;
-    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-  };
 
   // 이메일, 비밀번호 정보 없는 상태에서 URL에 /signup/profile하면 회원가입 페이지로 이동
   useEffect(() => {
@@ -100,7 +51,6 @@ function ProfileSetting() {
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
           setAccountNameValid(false);
           setAccountNameWarningMsg('* 이미 가입된 계정ID 입니다.');
-          inputRef.current.focus();
         } else {
           const response = await authAxios.post('/', {
             user: {
@@ -109,7 +59,7 @@ function ProfileSetting() {
               password: state.password,
               accountname: accountName,
               intro,
-              image: `https://mandarin.api.weniv.co.kr/${image}`,
+              image,
             },
           });
 
@@ -134,56 +84,12 @@ function ProfileSetting() {
     <S.Container>
       <Title>프로필 설정</Title>
       <S.SubText>나중에 언제든지 변경할 수 있습니다.</S.SubText>
-      <ProfileImageInput handleProfileImage={handleProfileImage} />
-      <S.FormContainer>
-        <AuthInputForm
-          id="id"
-          label="사용자 ID"
-          inputProps={{
-            type: 'text',
-            placeholder: '아이디를 입력해주세요',
-          }}
-          handleProfileState={handleAccountName}
-          inputValue={accountName}
-          profileValid={accountNameValid}
-          warningMsg={accountNameWarningMsg}
-          inputRef={inputRef}
-        />
-        <AuthInputForm
-          id="name"
-          label="사용자 이름"
-          inputProps={{
-            type: 'text',
-            placeholder: '이름을 입력해주세요',
-          }}
-          handleProfileState={handleUserName}
-          inputValue={userName}
-          profileValid={userNameValid}
-          warningMsg={userNameWarningMsg}
-        />
-        <S.IntroFormContainer>
-          <S.Label htmlFor="intro">소개</S.Label>
-          <S.IntroContent
-            id="intro"
-            name="intro"
-            placeholder="소개글을 입력해주세요"
-            rows={1}
-            cols={20}
-            maxLength={100}
-            wrap="hard"
-            ref={textareaRef}
-            onInput={handleResizeHeight}
-            value={intro}
-            onChange={handleIntro}
-          />
-        </S.IntroFormContainer>
-        <S.JoinButton
-          text="후키 시작하기"
-          buttonStyle={LARGE_BUTTON}
-          disabled={buttonNotAllow}
-          onClick={handleStartClick}
-        />
-      </S.FormContainer>
+      <ProfileInfoForm />
+      <S.JoinButton
+        text="후키 시작하기"
+        buttonStyle={LARGE_BUTTON}
+        onClick={handleStartClick}
+      />
     </S.Container>
   );
 }

--- a/src/pages/Auth/ProfileSetting/index.jsx
+++ b/src/pages/Auth/ProfileSetting/index.jsx
@@ -7,10 +7,10 @@ import Title from '../../../components/Title';
 import { LARGE_BUTTON } from '../../../constants/buttonStyle';
 import authAxios from '../../../api/authAxios';
 import {
+  isSubscribedAccountState,
   profileAccountName,
-  profileAccountNameValid,
-  profileAccountNameWarningMessage,
   profileImage,
+  profileInputValid,
   profileIntro,
   profileUserName,
 } from '../../../atoms/profileInfo';
@@ -25,10 +25,9 @@ function ProfileSetting() {
   const image = useRecoilValue(profileImage);
   const intro = useRecoilValue(profileIntro);
 
-  const setAccountNameValid = useSetRecoilState(profileAccountNameValid);
-  const setAccountNameWarningMsg = useSetRecoilState(
-    profileAccountNameWarningMessage
-  );
+  const { accountNameValid, userNameValid } = useRecoilValue(profileInputValid);
+
+  const setIsSubscribedAccount = useSetRecoilState(isSubscribedAccountState);
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
@@ -36,6 +35,17 @@ function ProfileSetting() {
   useEffect(() => {
     if (!state?.email || !state?.password) navigate('/signup');
   }, []);
+
+  useEffect(() => {
+    if (accountNameValid && userNameValid) {
+      setIsSubscribedAccount({
+        accountNameValid: true,
+        validWarningMessage: '',
+      });
+      return setButtonNotAllow(false);
+    }
+    return setButtonNotAllow(true);
+  }, [accountName, userName]);
 
   const handleStartClick = useCallback(
     async (e) => {
@@ -49,8 +59,10 @@ function ProfileSetting() {
         });
 
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
-          setAccountNameValid(false);
-          setAccountNameWarningMsg('* 이미 가입된 계정ID 입니다.');
+          setIsSubscribedAccount({
+            accountNameValid: false,
+            validWarningMessage: '* 이미 가입된 사용자 ID 입니다.',
+          });
         } else {
           const response = await authAxios.post('/', {
             user: {
@@ -89,6 +101,7 @@ function ProfileSetting() {
         text="후키 시작하기"
         buttonStyle={LARGE_BUTTON}
         onClick={handleStartClick}
+        disabled={buttonNotAllow}
       />
     </S.Container>
   );

--- a/src/pages/Auth/ProfileSetting/index.style.js
+++ b/src/pages/Auth/ProfileSetting/index.style.js
@@ -45,4 +45,6 @@ export const IntroContent = styled.textarea`
   }
 `;
 
-export const JoinButton = styled(Button)``;
+export const JoinButton = styled(Button)`
+  margin-top: 2.5rem;
+`;

--- a/src/pages/Auth/ProfileSetting/index.style.js
+++ b/src/pages/Auth/ProfileSetting/index.style.js
@@ -15,36 +15,6 @@ export const SubText = styled.p`
   color: ${({ theme }) => theme.color.GRAY};
 `;
 
-export const FormContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 3.5rem;
-  width: 100%;
-`;
-
-export const IntroFormContainer = styled.div``;
-
-export const Label = styled.label`
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-`;
-
-export const IntroContent = styled.textarea`
-  display: block;
-  width: 100%;
-  margin-top: 0.7rem;
-  padding: 1.2rem 1.5rem;
-  word-wrap: break-word;
-  font-family: Arial;
-  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  border-radius: ${({ theme }) => theme.borderRadius.BASE};
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  color: ${({ theme }) => theme.color.DARK_GRAY};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.color.LIGHT_GRAY};
-  }
-`;
-
 export const JoinButton = styled(Button)`
   margin-top: 2.5rem;
 `;

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -110,7 +110,6 @@ function SignUp() {
             email: signUpEmail,
           },
         });
-
         if (res.data.message === '이미 가입된 이메일 주소 입니다.') {
           setEmailValid(false);
           setEmailWarningMsg('* 이미 가입된 이메일입니다.');

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -11,10 +11,10 @@ import authAxios from '../../../api/authAxios';
 import ConfirmHeader from '../../../components/common/ConfirmHeader';
 import ProfileInfoForm from '../../../components/Profile/ProfileInfoForm';
 import {
+  isSubscribedAccountState,
   profileAccountName,
-  profileAccountNameValid,
-  profileAccountNameWarningMessage,
   profileImage,
+  profileInputValid,
   profileIntro,
   profileUserName,
 } from '../../../atoms/profileInfo';
@@ -29,30 +29,26 @@ function ProfileEdit() {
   const image = useRecoilValue(profileImage);
   const intro = useRecoilValue(profileIntro);
 
-  const setAccountNameValid = useSetRecoilState(profileAccountNameValid);
-  const setAccountNameWarningMsg = useSetRecoilState(
-    profileAccountNameWarningMessage
-  );
+  const { accountNameValid, userNameValid } = useRecoilValue(profileInputValid);
+
+  const setIsSubscribedAccount = useSetRecoilState(isSubscribedAccountState);
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
-
-  // useEffect(() => {
-  //   setAccountName(state.accountName);
-  //   setUserName(state.userName);
-  //   setIntro(state.intro);
-  //   setImage(state.image);
-  // }, []);
 
   const goBackPage = () => {
     navigate(-1);
   };
 
-  // useEffect(() => {
-  //   if (accountNameValid && userNameValid) {
-  //     return setButtonNotAllow(false);
-  //   }
-  //   return setButtonNotAllow(true);
-  // }, [accountName, userName]);
+  useEffect(() => {
+    if (accountNameValid && userNameValid) {
+      setIsSubscribedAccount({
+        accountNameValid: true,
+        validWarningMessage: '',
+      });
+      return setButtonNotAllow(false);
+    }
+    return setButtonNotAllow(true);
+  }, [accountName, userName]);
 
   const handleStartClick = useCallback(
     async (e) => {
@@ -66,8 +62,10 @@ function ProfileEdit() {
         });
 
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
-          setAccountNameValid(false);
-          setAccountNameWarningMsg('* 이미 가입된 사용자 ID 입니다.');
+          setIsSubscribedAccount({
+            accountNameValid: false,
+            validWarningMessage: '* 이미 가입된 사용자 ID 입니다.',
+          });
         } else {
           const response = await authAxios.put(
             '',
@@ -112,6 +110,7 @@ function ProfileEdit() {
         leftClick={goBackPage}
         rightClick={handleStartClick}
         rightButtonText="수정"
+        buttonNotAllow={buttonNotAllow}
       />
       <S.Container>
         <ProfileInfoForm />

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import * as S from './index.styles';
 
@@ -8,24 +9,30 @@ import ProfileImageInput from '../../../components/ProfileImageInput';
 
 import authAxios from '../../../api/authAxios';
 import ConfirmHeader from '../../../components/common/ConfirmHeader';
+import ProfileInfoForm from '../../../components/Profile/ProfileInfoForm';
+import {
+  profileAccountName,
+  profileAccountNameValid,
+  profileAccountNameWarningMessage,
+  profileImage,
+  profileIntro,
+  profileUserName,
+} from '../../../atoms/profileInfo';
 
 function ProfileEdit() {
   const { state } = useLocation();
   console.log(state);
   const navigate = useNavigate();
-  const textareaRef = useRef(null);
-  const inputRef = useRef(null);
 
-  const [accountName, setAccountName] = useState('');
-  const [userName, setUserName] = useState('');
-  const [intro, setIntro] = useState('');
-  const [image, setImage] = useState('');
+  const userName = useRecoilValue(profileUserName);
+  const accountName = useRecoilValue(profileAccountName);
+  const image = useRecoilValue(profileImage);
+  const intro = useRecoilValue(profileIntro);
 
-  const [accountNameValid, setAccountNameValid] = useState(false);
-  const [userNameValid, setUserNameValid] = useState(false);
-
-  const [accountNameWarningMsg, setAccountNameWarningMsg] = useState('');
-  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
+  const setAccountNameValid = useSetRecoilState(profileAccountNameValid);
+  const setAccountNameWarningMsg = useSetRecoilState(
+    profileAccountNameWarningMessage
+  );
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
 
@@ -36,63 +43,16 @@ function ProfileEdit() {
   //   setImage(state.image);
   // }, []);
 
-  const handleAccountName = (e) => {
-    setAccountName(e.target.value);
-  };
-  const handleUserName = (e) => {
-    setUserName(e.target.value);
-  };
-  const handleIntro = (e) => {
-    setIntro(e.target.value);
-  };
-
   const goBackPage = () => {
     navigate(-1);
   };
 
-  // 자식 컴포넌트에서 이미지 src 가져오기
-  const handleProfileImage = (targetImage) => {
-    setImage(targetImage);
-  };
-
-  // 인풋창 입력할 때마다 유효성 검사
-  useEffect(() => {
-    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
-    console.log(accountName);
-    if (ID_REGEX.test(accountName)) {
-      setAccountNameValid(true);
-    } else {
-      setAccountNameValid(false);
-      setAccountNameWarningMsg(
-        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
-      );
-    }
-
-    if (userName.length < 2 || userName.length > 10) {
-      setUserNameValid(false);
-      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
-    } else {
-      setUserNameValid(true);
-    }
-  }, [accountName, userName]);
-
-  useEffect(() => {
-    if (accountNameValid && userNameValid) {
-      return setButtonNotAllow(false);
-    }
-    return setButtonNotAllow(true);
-  }, [accountName, userName]);
-
-  // 아이디 인풋창 자동 포커스
-  useEffect(() => {
-    inputRef.current.focus();
-  }, []);
-
-  // 소개 textarea 높이
-  const handleResizeHeight = () => {
-    textareaRef.current.style.height = `38px`;
-    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-  };
+  // useEffect(() => {
+  //   if (accountNameValid && userNameValid) {
+  //     return setButtonNotAllow(false);
+  //   }
+  //   return setButtonNotAllow(true);
+  // }, [accountName, userName]);
 
   const handleStartClick = useCallback(
     async (e) => {
@@ -108,7 +68,6 @@ function ProfileEdit() {
         if (res.data.message === '이미 가입된 계정ID 입니다.') {
           setAccountNameValid(false);
           setAccountNameWarningMsg('* 이미 가입된 사용자 ID 입니다.');
-          inputRef.current.focus();
         } else {
           const response = await authAxios.put(
             '',
@@ -117,7 +76,7 @@ function ProfileEdit() {
                 username: userName,
                 accountname: accountName,
                 intro,
-                image: `https://mandarin.api.weniv.co.kr/${image}`,
+                image,
               },
             },
             {
@@ -153,53 +112,9 @@ function ProfileEdit() {
         leftClick={goBackPage}
         rightClick={handleStartClick}
         rightButtonText="수정"
-        buttonNotAllow={buttonNotAllow}
       />
       <S.Container>
-        <ProfileImageInput handleProfileImage={handleProfileImage} />
-        <S.FormContainer>
-          <AuthInputForm
-            id="id"
-            label="사용자 ID"
-            inputProps={{
-              type: 'text',
-              placeholder: '아이디를 입력해주세요',
-            }}
-            handleProfileState={handleAccountName}
-            inputValue={accountName}
-            profileValid={accountNameValid}
-            warningMsg={accountNameWarningMsg}
-            inputRef={inputRef}
-          />
-          <AuthInputForm
-            id="name"
-            label="사용자 이름"
-            inputProps={{
-              type: 'text',
-              placeholder: '이름을 입력해주세요',
-            }}
-            handleProfileState={handleUserName}
-            inputValue={userName}
-            profileValid={userNameValid}
-            warningMsg={userNameWarningMsg}
-          />
-          <S.IntroFormContainer>
-            <S.Label htmlFor="intro">소개</S.Label>
-            <S.IntroContent
-              id="intro"
-              name="intro"
-              placeholder="소개글을 입력해주세요"
-              rows={1}
-              cols={20}
-              maxLength={100}
-              wrap="hard"
-              ref={textareaRef}
-              onInput={handleResizeHeight}
-              value={intro}
-              onChange={handleIntro}
-            />
-          </S.IntroFormContainer>
-        </S.FormContainer>
+        <ProfileInfoForm />
       </S.Container>
     </>
   );

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -1,7 +1,199 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import * as S from './index.styles';
+
+import AuthInputForm from '../../../components/AuthInputForm';
+import ProfileImageInput from '../../../components/ProfileImageInput';
+
+import authAxios from '../../../api/authAxios';
+import ConfirmHeader from '../../../components/common/ConfirmHeader';
 
 function ProfileEdit() {
-  return <div>ProfileEdit</div>;
+  const navigate = useNavigate();
+  const textareaRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const [accountName, setAccountName] = useState('');
+  const [userName, setUserName] = useState('');
+  const [intro, setIntro] = useState('');
+  const [image, setImage] = useState('');
+
+  const [accountNameValid, setAccountNameValid] = useState(false);
+  const [userNameValid, setUserNameValid] = useState(false);
+
+  const [accountNameWarningMsg, setAccountNameWarningMsg] = useState('');
+  const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
+
+  const [buttonNotAllow, setButtonNotAllow] = useState(true);
+
+  const handleAccountName = (e) => {
+    setAccountName(e.target.value);
+  };
+  const handleUserName = (e) => {
+    setUserName(e.target.value);
+  };
+  const handleIntro = (e) => {
+    setIntro(e.target.value);
+  };
+
+  const goBackPage = () => {
+    navigate(-1);
+  };
+
+  // 자식 컴포넌트에서 이미지 src 가져오기
+  const handleProfileImage = (targetImage) => {
+    setImage(targetImage);
+  };
+
+  // 인풋창 입력할 때마다 유효성 검사
+  useEffect(() => {
+    const ID_REGEX = /^[a-z0-9A-Z_.]{2,16}$/;
+    console.log(accountName);
+    if (ID_REGEX.test(accountName)) {
+      setAccountNameValid(true);
+    } else {
+      setAccountNameValid(false);
+      setAccountNameWarningMsg(
+        '* 2~16자 이내의 영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.'
+      );
+    }
+
+    if (userName.length < 2 || userName.length > 10) {
+      setUserNameValid(false);
+      setUserNameWarningMsg('* 2~10자 이내로 입력해주세요');
+    } else {
+      setUserNameValid(true);
+    }
+  }, [accountName, userName]);
+
+  useEffect(() => {
+    if (accountNameValid && userNameValid) {
+      return setButtonNotAllow(false);
+    }
+    return setButtonNotAllow(true);
+  }, [accountName, userName]);
+
+  // 아이디 인풋창 자동 포커스
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
+
+  // 소개 textarea 높이
+  const handleResizeHeight = () => {
+    textareaRef.current.style.height = `38px`;
+    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+  };
+
+  const handleStartClick = useCallback(
+    async (e) => {
+      e.preventDefault();
+      console.log(userName, accountName, image, intro);
+      try {
+        const res = await authAxios.post('/accountnamevalid', {
+          user: {
+            accountname: accountName,
+          },
+        });
+
+        if (res.data.message === '이미 가입된 계정ID 입니다.') {
+          setAccountNameValid(false);
+          setAccountNameWarningMsg('* 이미 가입된 사용자 ID 입니다.');
+          inputRef.current.focus();
+        } else {
+          const response = await authAxios.put(
+            '',
+            {
+              user: {
+                username: userName,
+                accountname: accountName,
+                intro,
+                image: `https://mandarin.api.weniv.co.kr/${image}`,
+              },
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${JSON.parse(
+                  localStorage.getItem('token')
+                )}`,
+                'Content-type': 'application/json',
+              },
+            }
+          );
+
+          console.log(response);
+          if (response.statusText === 'OK') {
+            const userData = response.data.user;
+            const { accountname } = userData;
+
+            localStorage.setItem('accountName', JSON.stringify(accountname));
+
+            navigate(`/profile/${accountname}`);
+          }
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [userName, accountName, intro]
+  );
+
+  return (
+    <>
+      <ConfirmHeader
+        leftClick={goBackPage}
+        rightClick={handleStartClick}
+        rightButtonText="수정"
+        buttonNotAllow={buttonNotAllow}
+      />
+      <S.Container>
+        <ProfileImageInput handleProfileImage={handleProfileImage} />
+        <S.FormContainer>
+          <AuthInputForm
+            id="id"
+            label="사용자 ID"
+            inputProps={{
+              type: 'text',
+              placeholder: '아이디를 입력해주세요',
+            }}
+            handleProfileState={handleAccountName}
+            inputValue={accountName}
+            profileValid={accountNameValid}
+            warningMsg={accountNameWarningMsg}
+            inputRef={inputRef}
+          />
+          <AuthInputForm
+            id="name"
+            label="사용자 이름"
+            inputProps={{
+              type: 'text',
+              placeholder: '이름을 입력해주세요',
+            }}
+            handleProfileState={handleUserName}
+            inputValue={userName}
+            profileValid={userNameValid}
+            warningMsg={userNameWarningMsg}
+          />
+          <S.IntroFormContainer>
+            <S.Label htmlFor="intro">소개</S.Label>
+            <S.IntroContent
+              id="intro"
+              name="intro"
+              placeholder="소개글을 입력해주세요"
+              rows={1}
+              cols={20}
+              maxLength={100}
+              wrap="hard"
+              ref={textareaRef}
+              onInput={handleResizeHeight}
+              value={intro}
+              onChange={handleIntro}
+            />
+          </S.IntroFormContainer>
+        </S.FormContainer>
+      </S.Container>
+    </>
+  );
 }
 
 export default ProfileEdit;

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -113,7 +113,7 @@ function ProfileEdit() {
         buttonNotAllow={buttonNotAllow}
       />
       <S.Container>
-        <ProfileInfoForm />
+        <ProfileInfoForm edit savedData={state} />
       </S.Container>
     </>
   );

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import * as S from './index.styles';
 
@@ -10,6 +10,8 @@ import authAxios from '../../../api/authAxios';
 import ConfirmHeader from '../../../components/common/ConfirmHeader';
 
 function ProfileEdit() {
+  const { state } = useLocation();
+  console.log(state);
   const navigate = useNavigate();
   const textareaRef = useRef(null);
   const inputRef = useRef(null);
@@ -26,6 +28,13 @@ function ProfileEdit() {
   const [userNameWarningMsg, setUserNameWarningMsg] = useState('');
 
   const [buttonNotAllow, setButtonNotAllow] = useState(true);
+
+  // useEffect(() => {
+  //   setAccountName(state.accountName);
+  //   setUserName(state.userName);
+  //   setIntro(state.intro);
+  //   setImage(state.image);
+  // }, []);
 
   const handleAccountName = (e) => {
     setAccountName(e.target.value);

--- a/src/pages/Profile/ProfileEdit/index.jsx
+++ b/src/pages/Profile/ProfileEdit/index.jsx
@@ -4,9 +4,6 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import * as S from './index.styles';
 
-import AuthInputForm from '../../../components/AuthInputForm';
-import ProfileImageInput from '../../../components/ProfileImageInput';
-
 import authAxios from '../../../api/authAxios';
 import ConfirmHeader from '../../../components/common/ConfirmHeader';
 import ProfileInfoForm from '../../../components/Profile/ProfileInfoForm';

--- a/src/pages/Profile/ProfileEdit/index.styles.js
+++ b/src/pages/Profile/ProfileEdit/index.styles.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -6,46 +6,4 @@ export const Container = styled.div`
   align-items: center;
   padding: 3.4rem;
   height: 100vh;
-`;
-
-export const SubText = styled.p`
-  margin: 0.5rem 0;
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  color: ${({ theme }) => theme.color.GRAY};
-`;
-
-export const FormContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 3.5rem;
-  width: 100%;
-`;
-
-export const IntroFormContainer = styled.div``;
-
-export const Label = styled.label`
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-`;
-
-export const IntroContent = styled.textarea`
-  display: block;
-  width: 100%;
-  margin-top: 0.7rem;
-  padding: 1.2rem 1.5rem;
-  word-wrap: break-word;
-  font-family: Arial;
-  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
-  border-radius: ${({ theme }) => theme.borderRadius.BASE};
-  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
-  color: ${({ theme }) => theme.color.DARK_GRAY};
-
-  ${({ value }) =>
-    value.length > 0 &&
-    css`
-      border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
-    `}
-
-  &::placeholder {
-    color: ${({ theme }) => theme.color.LIGHT_GRAY};
-  }
 `;

--- a/src/pages/Profile/ProfileEdit/index.styles.js
+++ b/src/pages/Profile/ProfileEdit/index.styles.js
@@ -1,0 +1,51 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3.4rem;
+  height: 100vh;
+`;
+
+export const SubText = styled.p`
+  margin: 0.5rem 0;
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.GRAY};
+`;
+
+export const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  width: 100%;
+`;
+
+export const IntroFormContainer = styled.div``;
+
+export const Label = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+`;
+
+export const IntroContent = styled.textarea`
+  display: block;
+  width: 100%;
+  margin-top: 0.7rem;
+  padding: 1.2rem 1.5rem;
+  word-wrap: break-word;
+  font-family: Arial;
+  border: 1px solid ${({ theme }) => theme.color.LIGHT_GRAY};
+  border-radius: ${({ theme }) => theme.borderRadius.BASE};
+  font-size: ${({ theme }) => theme.fontSize.MEDIUM};
+  color: ${({ theme }) => theme.color.DARK_GRAY};
+
+  ${({ value }) =>
+    value.length > 0 &&
+    css`
+      border: 1px solid ${({ theme }) => theme.color.ACTIVE_BLUE};
+    `}
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.LIGHT_GRAY};
+  }
+`;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 프로필 수정 클릭 시 기존 프로필 정보를 갖고 있는 프로필 수정 페이지로 이동, 수정 기능 추가
- [x] 마크업 & 스타일 : 프로필 수정 페이지 UI 작성
- [x] 리팩토링 : 프로필 세팅과 프로필 수정 페이지의 중복되는 컴포넌트를 분리하여 재사용
- [x] 개발 환경 세팅 : eslint rules 변경 (하나의 export만 있는 경우 export default를 무조건 사용해야 하는 rule 삭제, styled-compnents의 컨벤션을 맞추기 위해서)

## 💬 전달사항
- 간혈적으로 프로필 세팅이나 프로필 수정에서 이미지를 변경하고 완료를 눌러도 이미지가 변경되지 않는 현상이 발생합니다. 
  - isLoading이나 try catch로 잡아야할 듯 합니다 

## 💬 스크린샷
![Dec-27-2022 01-32-58](https://user-images.githubusercontent.com/71367408/209568266-2f0ca4d1-bcfd-4903-93e2-af748f0fa812.gif)


## 💬 Issue Number
close : #99 
