### PR TITLE
프로필 이동 시 내 프로필로 돌아와도 내 프로필로 변하지 않는 현상 해결

### DIFF
--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -19,8 +19,9 @@ function UserInfo({ isMyPage, accountName }) {
   const [snackBarMessage, setSnackBarMessage] = useState('');
   const navigate = useNavigate();
 
-  const { data, isLoading, isError } = useQuery('profileInfo', () =>
-    getProfileInfo(accountName)
+  const { data, isLoading, isError } = useQuery(
+    ['profileInfo', accountName],
+    () => getProfileInfo(accountName)
   );
 
   const followUser = useMutation(() => postFollow(accountName), {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 import { Reset } from 'styled-reset';
 import { ThemeProvider } from 'styled-components';
@@ -21,7 +20,6 @@ root.render(
           <App />
         </ThemeProvider>
       </RecoilRoot>
-      <ReactQueryDevtools />
     </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 버그 수정 : 다른 사람 프로필로 이동 후 내 프로필로 돌아와도 내 프로필이 나타나지 않는 현상 해결


## 💬 전달사항
- 구분 되는 데이터를 react-query로 불러오는 경우, 각자 고유한 키를 줍시다..!


## 💬 스크린샷
![Dec-28-2022 17-46-49](https://user-images.githubusercontent.com/71367408/209785315-bb02dae7-e25b-4502-bef2-b40c4356bd25.gif)


## 💬 Issue Number
close : #123 
