### PR TITLE
프로필 수정에서 accountName을 변경할 수 없도록 수정, 프로필 수정 코드 리팩토링

### DIFF
--- a/src/api/authAxios.js
+++ b/src/api/authAxios.js
@@ -7,4 +7,26 @@ const authAxios = axios.create({
   },
 });
 
+export const editProfile = async (userName, accountName, intro, image) => {
+  const { data } = await authAxios.put(
+    '',
+    {
+      user: {
+        username: userName,
+        accountname: accountName,
+        intro,
+        image,
+      },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+        'Content-type': 'application/json',
+      },
+    }
+  );
+
+  return data;
+};
+
 export default authAxios;

--- a/src/components/AuthInputForm/index.jsx
+++ b/src/components/AuthInputForm/index.jsx
@@ -63,6 +63,7 @@ function AuthInputForm({
   profileValid,
   isCorrect,
   inputRef,
+  edit,
 }) {
   const location = useLocation();
 
@@ -95,6 +96,7 @@ function AuthInputForm({
         isCorrect={isCorrect}
         onChange={setState}
         onKeyDown={setState}
+        disabled={edit}
       />
       {!signUpValid && !profileValid && inputValue?.length > 0 && (
         <WarningMessage>{warningMsg}</WarningMessage>

--- a/src/components/Profile/ProfileInfoForm/index.jsx
+++ b/src/components/Profile/ProfileInfoForm/index.jsx
@@ -83,6 +83,7 @@ function ProfileInfoForm({ edit, savedData }) {
               : isSubscribedAccount.validWarningMessage
           }
           inputRef={inputRef}
+          edit={edit}
         />
         <AuthInputForm
           id="name"

--- a/src/components/Profile/UserInfo/index.styles.js
+++ b/src/components/Profile/UserInfo/index.styles.js
@@ -42,7 +42,7 @@ export const ProfileImage = styled.img`
   min-height: 11rem;
   height: 11rem;
 
-  object-fit: cover;
+  object-fit: contain;
 
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
 `;

--- a/src/components/ProfileImageInput/index.jsx
+++ b/src/components/ProfileImageInput/index.jsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
+import { useMutation } from 'react-query';
 import axios from 'axios';
 
 import * as S from './index.style';
 import basicProfileImage from '../../assets/basic-profile.png';
 import { profileImage } from '../../atoms/profileInfo';
+
+import getImageFilename from '../../api/image';
 
 function ProfileImageInput({ savedImage }) {
   const [profileImages, setProfileImages] = useState('');
@@ -12,7 +15,6 @@ function ProfileImageInput({ savedImage }) {
   const imageInput = useRef(null);
 
   useEffect(() => {
-    console.log(savedImage);
     if (savedImage) {
       setProfileImages(savedImage);
       setImage(savedImage);
@@ -21,35 +23,21 @@ function ProfileImageInput({ savedImage }) {
     }
   }, []);
 
-  const fetchImage = async (image) => {
-    const formData = new FormData();
-
-    formData.append('image', image);
-
-    try {
-      const res = await axios.post(
-        `https://mandarin.api.weniv.co.kr/image/uploadfile`,
-        formData
-      );
-
-      setProfileImages(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
-      setImage(`https://mandarin.api.weniv.co.kr/${res.data.filename}`);
-
-      return res.data.filename;
-    } catch (error) {
-      return error;
-    }
-  };
+  const postImageFile = useMutation((image) => getImageFilename(image), {
+    onSuccess: (data) => {
+      setImage(`https://mandarin.api.weniv.co.kr/${data}`);
+      setProfileImages(`https://mandarin.api.weniv.co.kr/${data}`);
+    },
+  });
 
   const handleImageChange = useCallback((e) => {
     const currentImage = e.target.files[0];
-    console.log(currentImage);
 
     if (currentImage) {
-      fetchImage(currentImage);
+      postImageFile.mutate(currentImage);
     } else {
       setProfileImages(basicProfileImage);
-      fetchImage(basicProfileImage);
+      setImage('');
     }
   }, []);
 

--- a/src/components/ProfileImageInput/index.style.js
+++ b/src/components/ProfileImageInput/index.style.js
@@ -24,6 +24,6 @@ export const ImageInput = styled.img`
   height: 12rem;
   margin: 0 auto;
   border-radius: ${({ theme }) => theme.borderRadius.ROUND};
-  object-fit: cover;
+  object-fit: contain;
   cursor: pointer;
 `;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가 : 프로필 수정인 경우 접근 불가능하게 변경, 프로필 수정 시 변경된 이미지를 localstorage에 저장
- [x] 마크업 & 스타일 : 프로필 이미지, 수정이미지 contain으로 변경
- [x] 리팩토링 : 프로필 이미지 추가 로직, 프로필 수정 로직 react-query로 리팩토링


## 💬 스크린샷
<img width="386" alt="image" src="https://user-images.githubusercontent.com/71367408/209913832-bed03b3b-709a-474b-9a8b-61e990629818.png">


## 💬 Issue Number
close : #125 
