### PR TITLE
유효성 검사 후 가입하지 않은 이메일임에도 가입 되었다는 오류

### DIFF
--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -92,6 +92,7 @@ function SignUp() {
             email: signUpEmail,
           },
         });
+
         if (res.data.message === '이미 가입된 이메일 주소 입니다.') {
           setEmailValid(false);
           setEmailWarningMsg('* 이미 가입된 이메일입니다.');
@@ -110,7 +111,7 @@ function SignUp() {
         console.error(error);
       }
     },
-    [buttonNotAllow]
+    [signUpEmail]
   );
 
   return (

--- a/src/pages/Auth/SignUp/index.jsx
+++ b/src/pages/Auth/SignUp/index.jsx
@@ -111,7 +111,7 @@ function SignUp() {
         console.error(error);
       }
     },
-    [signUpEmail]
+    [signUpEmail, buttonNotAllow]
   );
 
   return (


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 버그 수정 : 가입된 이메일 유효성 검사 진행 후 가입되지 않은 이메일 입력하면 이미 가입되었다는 오류 해결

## 💬 기대 결과
- 의존성 배열 값이 `buttonNotAllow`로만 설정되어있었는데 `hookie17@gmail.com`에서 7을 지운 뒤 어떠한 값을 입력하거나 지워도 buttonNotAllow의 불리언 값의 변화가 한번만 일어나게 됩니다.
아래 사진과 같이 이렇게 의도와 다른 값이 전달되어 발생한 에러
기존 `hookie1@gmail.com` 이메일이 가입되어있던 상태라 `hookie18@gmail.com`을 입력해도 `hookie1@gmail.com`의 값이 전달 되기 때문
<img width="348" alt="스크린샷 2022-12-29 오후 10 50 40" src="https://user-images.githubusercontent.com/101461874/209965972-84821a42-1e74-4cb8-a1eb-38fad3f90b84.png">

## 💬 전달사항
- `handleJoinClick()` useCallback의 Dependency array의 값으로 인한 에러


## 💬 Issue Number
close : #132 
