### PR TITLE
다른 팔로워의 프로필 페이지에서 홈페이지로 이동하면 발생하는 키에러 수정

### DIFF
--- a/src/components/Profile/ProfilePost/index.jsx
+++ b/src/components/Profile/ProfilePost/index.jsx
@@ -16,8 +16,9 @@ import PostList from '../../Post/PostList';
 function ProfilePost({ accountName }) {
   const [isListPost, setIsListPost] = useState(true);
 
-  const { data, isLoading, isError } = useQuery('myPostList', () =>
-    getAccountPost(accountName)
+  const { data, isLoading, isError } = useQuery(
+    ['profilePostList', accountName],
+    () => getAccountPost(accountName)
   );
 
   const handleListPost = () => {

--- a/src/components/Profile/UserInfo/index.jsx
+++ b/src/components/Profile/UserInfo/index.jsx
@@ -26,12 +26,12 @@ function UserInfo({ isMyPage, accountName }) {
 
   const followUser = useMutation(() => postFollow(accountName), {
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries(['profileInfo']);
     },
   });
   const unFollowUser = useMutation(() => deleteFollow(accountName), {
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries(['profileInfo']);
     },
   });
 


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 버그 수정 : 다른 팔로워의 프로필 페이지에서 홈페이지로 이동하면 발생하는 키에러 수정

## 💬 전달사항
1. 내가 내 프로필에서 홈페이지로 이동할때
    1. 내가 내 프로필로 이동 => myPostList 쿼리 키에 나의 data가 등록됨
    2. 홈페이지로 이동 
        1. myPostList 쿼리 키에 나의 data가 등록됨
        2. followPostList 쿼리 키에 나의 팔로워 피드가 등록됨 
2. 내가 다른 사람 프로필에서 홈페이지로 이동할때
    1. 내가 다른 사람 프로필로 이동 => myPostList 쿼리 키에 해당 유저의 data가 등록됨
    2. 홈페이지로 이동
        1. myPostList 쿼리 키에 나의 data가 등록됨 
            1. 이전 캐시된 데이터(다른 사람 프로필에서 저장된 해당 유저의 feed data)와 나의 feed data가 모두 불려와짐 
        2. followPostList 쿼리 키에 나의 팔로워 피드가 등록됨

때문에 follower의 게시글이 두번 불려와져서 문제가 발생
=> 프로필 페이지의 쿼리키를 분리하여 해결


## 💬 스크린샷
![키에러 해결](https://user-images.githubusercontent.com/71367408/209979369-11a81f39-baaf-4c1a-899a-08d7f692ed56.gif)


## 💬 Issue Number
close : #136 
