### PR TITLE
팔로워/팔로잉 페이지 스타일 분리 및 오류 수정

### DIFF
--- a/src/components/FollowItem/index.jsx
+++ b/src/components/FollowItem/index.jsx
@@ -1,56 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import styled from 'styled-components';
 
-import Button from '../common/Button';
-import { FOLLOW_BUTTON } from '../../constants/buttonStyle';
-
-import { slEllipsis } from '../../styles/Util';
+import * as S from './index.styles';
 import basicProfileImage from '../../assets/basic-profile.png';
+import { FOLLOW_BUTTON } from '../../constants/buttonStyle';
 import Snackbar from '../Modal/SnackBar';
-
-const SContent = styled.li`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.6rem;
-`;
-
-const SUserInfo = styled.div`
-  width: 65%;
-  margin: 0 1.2rem;
-`;
-
-const SImg = styled.img`
-  width: 5rem;
-  border-radius: 50%;
-`;
-
-const SUserId = styled.p`
-  flex: 4 4 0;
-  margin-bottom: 0.6rem;
-  font-size: 1.4rem;
-`;
-
-const SAccountName = styled.span`
-  font-size: 1rem;
-  margin-left: 0.5rem;
-  color: ${({ theme }) => theme.SUB_TEXT};
-`;
-
-const SUserIntroduction = styled.p`
-  flex: 4 4 0;
-  font-size: 1.2rem;
-  color: ${({ theme }) => theme.SUB_TEXT};
-  ${slEllipsis}
-`;
-
-const SButton = styled(Button)`
-  flex: 1 1 0;
-  line-height: 1.4rem;
-  white-space: nowrap;
-`;
 
 function FollowItem({ data }) {
   const [followState, setFollowState] = useState(data.isfollow);
@@ -123,29 +78,29 @@ function FollowItem({ data }) {
   };
 
   return (
-    <SContent key={data.username}>
-      <SImg
+    <S.Content key={data.username}>
+      <S.Img
         src={data.image}
         alt="프로필 이미지"
         onError={handleErrorImage}
         onClick={handleToUserProfile}
       />
-      <SUserInfo onClick={handleToUserProfile}>
-        <SUserId>
+      <S.UserInfo onClick={handleToUserProfile}>
+        <S.UserId>
           {data.username}
-          <SAccountName>@{data.accountname}</SAccountName>
-        </SUserId>
-        <SUserIntroduction>{data.intro}</SUserIntroduction>
-      </SUserInfo>
+          <S.AccountName>@{data.accountname}</S.AccountName>
+        </S.UserId>
+        <S.UserIntroduction>{data.intro}</S.UserIntroduction>
+      </S.UserInfo>
       {followState ? (
-        <SButton
+        <S.CommonButton
           text="취소"
           buttonStyle={FOLLOW_BUTTON}
           onClick={handleIsFollow}
           cancel
         />
       ) : (
-        <SButton
+        <S.CommonButton
           text="팔로우"
           buttonStyle={FOLLOW_BUTTON}
           onClick={handleIsFollow}
@@ -154,7 +109,7 @@ function FollowItem({ data }) {
       {isSnackBarOpen && (
         <Snackbar content="자기 자신을 팔로우 할 수 없습니다." />
       )}
-    </SContent>
+    </S.Content>
   );
 }
 

--- a/src/components/FollowItem/index.styles.js
+++ b/src/components/FollowItem/index.styles.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+
+import Button from '../common/Button';
+
+import { slEllipsis } from '../../styles/Util';
+
+export const Content = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.6rem;
+`;
+
+export const UserInfo = styled.div`
+  width: 65%;
+  margin: 0 1.2rem;
+`;
+
+export const Img = styled.img`
+  width: 5rem;
+  border-radius: 50%;
+`;
+
+export const UserId = styled.p`
+  flex: 4 4 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.4rem;
+`;
+
+export const AccountName = styled.span`
+  font-size: 1rem;
+  margin-left: 0.5rem;
+  color: ${({ theme }) => theme.SUB_TEXT};
+`;
+
+export const UserIntroduction = styled.p`
+  flex: 4 4 0;
+  font-size: 1.2rem;
+  color: ${({ theme }) => theme.SUB_TEXT};
+  ${slEllipsis}
+`;
+
+export const CommonButton = styled(Button)`
+  flex: 1 1 0;
+  line-height: 1.4rem;
+  white-space: nowrap;
+`;

--- a/src/components/FollowItem/index.styles.js
+++ b/src/components/FollowItem/index.styles.js
@@ -18,7 +18,9 @@ export const UserInfo = styled.div`
 
 export const Img = styled.img`
   width: 5rem;
+  height: 5rem;
   border-radius: 50%;
+  object-fit: cover;
 `;
 
 export const UserId = styled.p`

--- a/src/pages/Profile/Follower/index.jsx
+++ b/src/pages/Profile/Follower/index.jsx
@@ -1,20 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import styled from 'styled-components';
 import axios from 'axios';
 
+import * as S from './index.styles';
 import BaseHeader from '../../../components/common/BaseHeader';
 import FollowItem from '../../../components/FollowItem';
 
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
-import { IR } from '../../../styles/Util';
-
-const SFollowerList = styled.ul`
-  padding: 24px 16px 0;
-  h2 {
-    ${IR}
-  }
-`;
 
 function Follower() {
   const navigate = useNavigate();
@@ -56,13 +48,13 @@ function Follower() {
         leftClick={handleToProfile}
         title="Followers"
       />
-      <SFollowerList>
+      <S.FollowerList>
         <h2>팔로워 페이지</h2>
         {followerData.length > 0 &&
           followerData.map((data) => (
             <FollowItem key={data.accountname} data={data} />
           ))}
-      </SFollowerList>
+      </S.FollowerList>
     </>
   );
 }

--- a/src/pages/Profile/Follower/index.styles.js
+++ b/src/pages/Profile/Follower/index.styles.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { IR } from '../../../styles/Util';
+
+export const FollowerList = styled.ul`
+  padding: 24px 16px 0;
+  h2 {
+    ${IR}
+  }
+`;

--- a/src/pages/Profile/Following/index.jsx
+++ b/src/pages/Profile/Following/index.jsx
@@ -1,20 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import styled from 'styled-components';
 import axios from 'axios';
 
+import * as S from './index.styles';
 import BaseHeader from '../../../components/common/BaseHeader';
 import FollowItem from '../../../components/FollowItem';
 
 import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
-import { IR } from '../../../styles/Util';
-
-const SFollowerList = styled.ul`
-  padding: 24px 16px 0;
-  h2 {
-    ${IR}
-  }
-`;
 
 function Following() {
   const navigate = useNavigate();
@@ -56,13 +48,13 @@ function Following() {
         leftClick={handleToProfile}
         title="Followings"
       />
-      <SFollowerList>
+      <S.FollowerList>
         <h2>팔로잉 페이지</h2>
         {followingData.length > 0 &&
           followingData.map((data) => (
             <FollowItem key={data.accountname} data={data} />
           ))}
-      </SFollowerList>
+      </S.FollowerList>
     </>
   );
 }

--- a/src/pages/Profile/Following/index.styles.js
+++ b/src/pages/Profile/Following/index.styles.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { IR } from '../../../styles/Util';
+
+export const FollowerList = styled.ul`
+  padding: 24px 16px 0;
+  h2 {
+    ${IR}
+  }
+`;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 마크업 & 스타일 : 팔로워/팔로잉 페이지 스타일 파일을 따로 분리
- [x] 버그 수정 : 팔로우 아이템 프로필 이미지 레이아웃 깨짐 현상 수정

## 💬 스크린샷
전
<img width="331" alt="스크린샷 2022-12-31 17 37 33" src="https://user-images.githubusercontent.com/74060716/210130729-fd5bb33b-4160-48ee-bada-e6edcecf35e9.png">

후
<img width="329" alt="스크린샷 2022-12-31 17 37 49" src="https://user-images.githubusercontent.com/74060716/210130736-b601491a-2507-4a58-bd60-d51c32634d19.png">

## 💬 Issue Number
close : #147 
