### PR TITLE
게시글 상세 페이지 모든 댓글이 보이도록 구현

### DIFF
--- a/src/api/comment.js
+++ b/src/api/comment.js
@@ -5,12 +5,15 @@ const fetcher = axios.create({
 });
 
 export const getCommentList = async (postId) => {
-  const { data } = await fetcher.get(`/post/${postId}/comments`, {
-    headers: {
-      Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
-      'Content-type': 'application/json',
-    },
-  });
+  const { data } = await fetcher.get(
+    `/post/${postId}/comments/?limit=0&skip=0`,
+    {
+      headers: {
+        Authorization: `Bearer ${JSON.parse(localStorage.getItem('token'))}`,
+        'Content-type': 'application/json',
+      },
+    }
+  );
 
   return data.comments;
 };


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 리팩토링 : 게시글 상세 페이지 모든 댓글이 보이도록 구현

## 💬 전달사항
댓글 갯수가 원래는 최신 댓글 기준으로 10개까지만 보였는데, 이제는 처음부터 끝까지 다 보입니다!

## 💬 스크린샷
![화면 기록 2023-01-03 17 48 02](https://user-images.githubusercontent.com/74060716/210325340-3bff125f-436d-4597-83ed-52d64c400cb4.gif)

## 💬 Issue Number
close : #185 
