### PR TITLE
다른 프로젝트의 계정의 글에 접근할 경우 발생하는 에러 해결

### DIFF
--- a/src/components/Post/PostItem/index.jsx
+++ b/src/components/Post/PostItem/index.jsx
@@ -21,6 +21,15 @@ import arrowIcon from '../../../assets/icon/icon-arrow-left.png';
 import { deleteMyPost, reportFollowPost } from '../../../api/post';
 import { deleteLikeFeed, postLikeFeed } from '../../../api/like';
 
+const hasTag = (content) => {
+  try {
+    JSON.parse(content);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 function PostItem({
   postId,
   content,
@@ -44,11 +53,18 @@ function PostItem({
   const navigate = useNavigate();
   const location = useLocation();
 
-  const jsonContents = JSON.parse(content);
-  const tagArray = jsonContents.tags;
-  const contents = jsonContents.content;
+  let tagArray;
+  let contents;
   const images = image.split(', ');
   const accountName = JSON.parse(localStorage.getItem('accountName'));
+
+  if (hasTag(content)) {
+    const jsonContents = JSON.parse(content);
+    tagArray = jsonContents.tags;
+    contents = jsonContents.content;
+  } else {
+    contents = content;
+  }
 
   const deletePost = useMutation(() => deleteMyPost(postId), {
     onSuccess: () => {
@@ -195,7 +211,7 @@ function PostItem({
         </S.UserInfoContainer>
         <S.Contents detail={detail}>
           <S.TagList>
-            {tagArray.map((tag) => (
+            {tagArray?.map((tag) => (
               <TagItem key={nanoid()} tagText={tag.text} tagColor={tag.color} />
             ))}
           </S.TagList>


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 버그 수정 : 불러온 post data에서 content가 JSON.parse이 가능한 content인지 처리하고 할당


## 💬 기대 결과
- 다른 프로젝트에서 만든 계정의 글을 불러올 수 있습니다.
- 다른 프로젝트의 이미지는 해당 프로젝트의 처리에 따라 보이는 것과 안보이는 것이 있습니다.


## 💬 Issue Number
close : #189 
